### PR TITLE
change hasher from siphash to fnv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ noisy-floats = ["noisy_float"]
 
 [dependencies]
 noisy_float = { version = "^0.1.1", optional = true }
+fnv = "^1.0.3"

--- a/src/core/collider.rs
+++ b/src/core/collider.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use fnv::FnvHashMap;
 use std::mem;
 use float::*;
 use core::events::{EventManager, EventKey, EventKeysMap, InternalEvent};
@@ -23,7 +23,7 @@ use util::TightSet;
 
 /// A structure that tracks hitboxes and returns collide/separate events.
 pub struct Collider<I: Interactivity = DefaultInteractivity> {
-    hitboxes: HashMap<HitboxId, HitboxInfo<I>>,
+    hitboxes: FnvHashMap<HitboxId, HitboxInfo<I>>,
     time: N64,
     grid: Grid,
     padding: R64,
@@ -56,7 +56,7 @@ impl <I: Interactivity> Collider<I> {
         assert!(cell_width > padding, "requires cell_width > padding");
         assert!(padding > 0.0, "requires padding > 0.0");
         Collider {
-            hitboxes : HashMap::new(),
+            hitboxes : FnvHashMap::default(),
             time : n64(0.0),
             grid : Grid::new(cell_width),
             padding : padding,
@@ -304,7 +304,7 @@ impl <I: Interactivity> Collider<I> {
     }
 }
 
-impl <I: Interactivity> EventKeysMap for HashMap<HitboxId, HitboxInfo<I>> {
+impl <I: Interactivity> EventKeysMap for FnvHashMap<HitboxId, HitboxInfo<I>> {
     fn event_keys_mut(&mut self, id: HitboxId) -> &mut TightSet<EventKey> {
         &mut self.get_mut(&id).unwrap().event_keys
     }

--- a/src/core/grid.rs
+++ b/src/core/grid.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{hash_map, HashMap, HashSet};
+use std::collections::hash_map;
+use fnv::{FnvHashMap, FnvHashSet};
 use std::cmp;
 use float::*;
 use core::{HitboxId, Hitbox};
@@ -42,13 +43,13 @@ impl GridArea {
 }
 
 pub struct Grid {
-    map: HashMap<GridKey, TightSet<HitboxId>>,
+    map: FnvHashMap<GridKey, TightSet<HitboxId>>,
     cell_width: R64
 }
 
 impl Grid {
     pub fn new(cell_width: R64) -> Grid {
-        Grid { map : HashMap::new(), cell_width: cell_width }
+        Grid { map : FnvHashMap::default(), cell_width: cell_width }
     }
 
     pub fn cell_period(&self, hitbox: &Hitbox, has_group: bool) -> N64 {
@@ -65,7 +66,7 @@ impl Grid {
     }
     
     pub fn update_hitbox(&mut self, hitbox_id: HitboxId, old_hitbox: (&Hitbox, Option<Group>),
-                         new_hitbox: (&Hitbox, Option<Group>), groups: &[Group]) -> Option<HashSet<HitboxId>>
+                         new_hitbox: (&Hitbox, Option<Group>), groups: &[Group]) -> Option<FnvHashSet<HitboxId>>
     {
         let (old_hitbox, old_group) = old_hitbox;
         let (new_hitbox, new_group) = new_hitbox;
@@ -88,8 +89,8 @@ impl Grid {
         })
     }
 
-    fn overlapping_ids(&self, hitbox_id: HitboxId, rect: IndexRect, groups: &[Group]) -> HashSet<HitboxId> {
-        let mut result = HashSet::new();
+    fn overlapping_ids(&self, hitbox_id: HitboxId, rect: IndexRect, groups: &[Group]) -> FnvHashSet<HitboxId> {
+        let mut result = FnvHashSet::default();
         for &group in groups {
             for coord in rect.iter() {
                 let key = GridKey { coord : coord, group : group };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@
 
 #[cfg(feature = "noisy-floats")]
 extern crate noisy_float;
+extern crate fnv;
 
 mod float;
 pub mod geom;

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashSet, hash_set};
+use std::collections::{hash_set, HashSet};
+use fnv::FnvHashSet;
 use std::borrow::Borrow;
 use std::hash::Hash;
 use float::*;
@@ -34,12 +35,12 @@ const MIN_TIGHT_SET_CAPACITY: usize = 4;
 
 #[derive(Clone)]
 pub struct TightSet<T: Hash + Eq> {
-    set: HashSet<T>
+    set: FnvHashSet<T>
 }
 
 impl <T: Hash + Eq> TightSet<T> {
     pub fn new() -> TightSet<T> {
-        TightSet { set : HashSet::with_capacity(MIN_TIGHT_SET_CAPACITY) }
+        TightSet { set : HashSet::with_capacity_and_hasher(MIN_TIGHT_SET_CAPACITY, Default::default()) }
     }
 
     pub fn insert(&mut self, value: T) -> bool {
@@ -74,7 +75,7 @@ impl <T: Hash + Eq> TightSet<T> {
         if self.set.capacity() <= MIN_TIGHT_SET_CAPACITY {
             self.set.clear();
         } else {
-            self.set = HashSet::with_capacity(MIN_TIGHT_SET_CAPACITY);
+            self.set = FnvHashSet::with_capacity_and_hasher(MIN_TIGHT_SET_CAPACITY, Default::default());
         }
     }
 }


### PR DESCRIPTION
fnv is hasher suitable for short keys but provides no protection against
collision attacks.

In collider keys are from 4 to 8 bytes where fnv is better, see
[benchmark](http://cglab.ca/~abeinges/blah/hash-rs/)
