### PR TITLE
Moved {cell_width, padding} from HbProfile to collider::Collider::new().

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,9 @@ struct DemoHbProfile { id: HbId } // add any additional identfying data to this 
 impl HbProfile for DemoHbProfile {
     fn id(&self) -> HbId { self.id }
     fn can_interact(&self, _other: &DemoHbProfile) -> bool { true }
-    fn cell_width() -> f64 { 4.0 }
-    fn padding() -> f64 { 0.01 }
 }
 
-let mut collider: Collider<DemoHbProfile> = Collider::new();
+let mut collider: Collider<DemoHbProfile> = Collider::new(4.0, 0.01);
 
 let hitbox = Shape::square(2.0).place(v2(-10.0, 0.0)).moving(v2(1.0, 0.0));
 let overlaps = collider.add_hitbox(DemoHbProfile { id: 0 }, hitbox);

--- a/src/core/collider.rs
+++ b/src/core/collider.rs
@@ -37,9 +37,25 @@ pub struct Collider<P: HbProfile> {
 
 impl <P: HbProfile> Collider<P> {
     /// Constructs a new `Collider` instance.
-    pub fn new() -> Collider<P> {
-        let cell_width = P::cell_width();
-        let padding = P::padding();
+    /// To reduce the number of overlaps that are tested, hitboxes are placed in
+    /// a sparse grid structure behind the scenes. `cell_width` is the width of
+    /// the cells used in that grid. If your game has a similar grid concept,
+    /// then it is usually a good choice to use the same cell width as that
+    /// grid. Otherwise, a good choice is to use a width that is slightly larger
+    /// than most of the hitboxes.
+    ///
+    /// Collider generates both `Collide` and `Separate` events. However, due to
+    /// numerical error, it is important that two hitboxes be a certain small
+    /// distance apart from each other after a collision before they are
+    /// considered separated. Otherwise, false separation events may occur if,
+    /// for example, a sprite runs into a wall and stops, still touching the
+    /// wall. `padding` is used to describe what this minimum separation
+    /// distance is. This should typically be something that is not visible to
+    /// the user, perhaps a fraction of a "pixel."
+    ///
+    /// Another restriction introduced by `padding` is that hitboxes are not
+    /// allowed to have a width or height smaller than `padding`.
+    pub fn new(cell_width: f64, padding: f64) -> Collider<P> {
         assert!(cell_width > padding, "requires cell_width > padding");
         assert!(padding > 0.0, "requires padding > 0.0");
         Collider {

--- a/src/core/dur_hitbox/mod.rs
+++ b/src/core/dur_hitbox/mod.rs
@@ -217,13 +217,13 @@ mod tests {
         assert_eq!(a.collide_time(&b), f64::INFINITY);
         assert_eq!(a.separate_time(&b, 0.1), 0.0);
 
-        b.value.shape == Shape::circle(2.0);
-        b.vel.resize == Vec2::zero();
+        b.value.shape = Shape::circle(2.0);
+        b.vel.resize = Vec2::zero();
         assert_eq!(a.collide_time(&b), f64::INFINITY);
         assert_eq!(a.separate_time(&b, 0.1), 0.0);
 
-        a.value.shape == Shape::circle(2.0);
-        a.vel.resize == Vec2::zero();
+        a.value.shape = Shape::circle(2.0);
+        a.vel.resize = Vec2::zero();
         assert_eq!(a.collide_time(&b), f64::INFINITY);
         assert_eq!(a.separate_time(&b, 0.1), 0.0);
     }
@@ -239,13 +239,13 @@ mod tests {
         assert_eq!(a.separate_time(&b, 0.1), f64::INFINITY);
         assert_eq!(a.collide_time(&b), 0.0);
 
-        b.value.shape == Shape::circle(2.0);
-        b.vel.resize == Vec2::zero();
+        b.value.shape = Shape::circle(2.0);
+        b.vel.resize = Vec2::zero();
         assert_eq!(a.separate_time(&b, 0.1), f64::INFINITY);
         assert_eq!(a.collide_time(&b), 0.0);
 
-        a.value.shape == Shape::circle(2.0);
-        a.vel.resize == Vec2::zero();
+        a.value.shape = Shape::circle(2.0);
+        a.vel.resize = Vec2::zero();
         assert_eq!(a.separate_time(&b, 0.1), f64::INFINITY);
         assert_eq!(a.collide_time(&b), 0.0);
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -190,31 +190,4 @@ pub trait HbProfile: Copy {
     /// This method should be consistent with `group` and `interact_groups`,
     /// although possibly more restrictive.
     fn can_interact(&self, other: &Self) -> bool;
-
-    /// The width of the cells used in the Collider grid.
-    ///
-    /// To reduce the number of overlaps that are tested,
-    /// hitboxes are placed in a sparse grid structure behind the scenes.
-    /// `cell_width` is the width of the cells used in that grid.
-    /// If your game has a similar grid concept, then it is usually a good choice
-    /// to use the same cell width as that grid.
-    /// Otherwise, a good choice is to use a width that is slightly larger
-    /// than most of the hitboxes.
-    fn cell_width() -> f64;
-
-    /// The minimum distance before two hitboxes are considered separated.
-    ///
-    /// Collider generates both `Collide` and `Separate` events.
-    /// However, due to numerical error, it is important that two hitboxes
-    /// be a certain small distance apart from each other after a collision
-    /// before they are considered separated.
-    /// Otherwise, false separation events may occur if, for example,
-    /// a sprite runs into a wall and stops, still touching the wall.
-    /// `padding` is used to describe what this minimum separation distance is.
-    /// This should typically be something that is not visible to the
-    /// user, perhaps a fraction of a "pixel."
-    ///
-    /// Another restriction introduced by `padding` is that hitboxes are not
-    /// allowed to have a width or height smaller than `padding`.
-    fn padding() -> f64;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,11 +52,9 @@
 //! impl HbProfile for DemoHbProfile {
 //!     fn id(&self) -> HbId { self.id }
 //!     fn can_interact(&self, _other: &DemoHbProfile) -> bool { true }
-//!     fn cell_width() -> f64 { 4.0 }
-//!     fn padding() -> f64 { 0.01 }
 //! }
 //!
-//! let mut collider: Collider<DemoHbProfile> = Collider::new();
+//! let mut collider: Collider<DemoHbProfile> = Collider::new(4.0, 0.01);
 //!
 //! let hitbox = Shape::square(2.0).place(v2(-10.0, 0.0)).moving(v2(1.0, 0.0));
 //! let overlaps = collider.add_hitbox(DemoHbProfile { id: 0 }, hitbox);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -28,8 +28,6 @@ impl From<HbId> for TestHbProfile {
 impl HbProfile for TestHbProfile {
     fn id(&self) -> HbId { self.id }
     fn can_interact(&self, _other: &TestHbProfile) -> bool { true }
-    fn cell_width() -> f64 { 4.0 }
-    fn padding() -> f64 { 0.25 }
 }
 
 fn advance_to_event(collider: &mut Collider<TestHbProfile>, time: f64) {
@@ -62,7 +60,7 @@ fn sort(mut vector: Vec<TestHbProfile>) -> Vec<TestHbProfile> {
 
 #[test]
 fn smoke_test() {
-    let mut collider = Collider::<TestHbProfile>::new();
+    let mut collider = Collider::<TestHbProfile>::new(4.0, 0.25);
 
     let mut hitbox = Shape::square(2.0).place(v2(-10.0, 0.0)).still();
     hitbox.vel.value = v2(1.0, 0.0);
@@ -83,7 +81,7 @@ fn smoke_test() {
 
 #[test]
 fn test_hitbox_updates() {
-    let mut collider = Collider::<TestHbProfile>::new();
+    let mut collider = Collider::<TestHbProfile>::new(4.0, 0.25);
 
     let mut hitbox = Shape::square(2.0).place(v2(-10.0, 0.0)).still();
     hitbox.vel.value = v2(1.0, 0.0);
@@ -159,7 +157,7 @@ fn test_hitbox_updates() {
 
 #[test]
 fn test_get_overlaps() {
-    let mut collider = Collider::<TestHbProfile>::new();
+    let mut collider = Collider::<TestHbProfile>::new(4.0, 0.25);
 
     collider.add_hitbox(0.into(), Shape::square(2.0).place(v2(-10.0, 0.0)).moving(v2(1.0, 0.0)));
     collider.add_hitbox(1.into(), Shape::circle(2.0).place(v2(10.0, 0.0)).moving(v2(-1.0, 0.0)));
@@ -204,7 +202,7 @@ fn test_get_overlaps() {
 
 #[test]
 fn test_query_overlaps() {
-    let mut collider = Collider::<TestHbProfile>::new();
+    let mut collider = Collider::<TestHbProfile>::new(4.0, 0.25);
 
     collider.add_hitbox(0.into(), Shape::square(2.0).place(v2(-5.0, 0.0)).moving(v2(1.0, 0.0)));
     collider.add_hitbox(1.into(), Shape::circle(2.0).place(v2(0.0, 0.0)).still());
@@ -219,7 +217,7 @@ fn test_query_overlaps() {
 
 #[test]
 fn test_separate_initial_overlap() {
-    let mut collider = Collider::<TestHbProfile>::new();
+    let mut collider = Collider::<TestHbProfile>::new(4.0, 0.25);
 
     let overlaps = collider.add_hitbox(0.into(), Shape::square(1.).place(v2(0., 0.)).moving(v2(0.0, 1.)));
     assert_eq!(overlaps, vec![]);


### PR DESCRIPTION
`cell_width()` and `padding()` were functions that didn't accept any arguments.  As a result, they could only return hard-coded values (or lookup values in a global dictionary, which would be awkward).  This commit removes both cell_width() and padding() functions from the HbProfile trait, and adds them as arguments to collider::Collider::new().  This allows you to create/destroy Collider instances on the fly, which can be useful in certain types of simulators.

**WARNING** I also accidentally committed changes I made to the tests in `src/core/dur_hitbox/mod.rs`. Please check that I didn't change the tests before accepting this commit (all tests passed with my changes).