### PR TITLE
Used `cargo fmt --all` + some hand fixups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # collider-rs
-Collider is a [Rust](https://www.rust-lang.org/) library for continuous 2D collision detection,
-for use with game developement.
+Collider is a [Rust](https://www.rust-lang.org/) library for continuous 2D
+collision detection, for use with game developement.
 
-This is a successor to a [Java library of the same name](https://github.com/SergiusIW/collider).
-As my focus has shifted from Java to Rust, I ported the library.
+This is a successor to a
+[Java library of the same name](https://github.com/SergiusIW/collider).  As my
+focus has shifted from Java to Rust, I ported the library.
 
 ### Crate
 
@@ -15,31 +16,29 @@ Documentation for Collider can be found [here](http://www.matthewmichelotti.com/
 
 ### Description
 
-Most game engines follow the approach of periodically updating the
-positions of all shapes and checking for collisions at a frozen snapshot in time.
+Most game engines follow the approach of periodically updating the positions of
+all shapes and checking for collisions at a frozen snapshot in time.
 [Continuous collision detection](https://en.wikipedia.org/wiki/Collision_detection#A_posteriori_.28discrete.29_versus_a_priori_.28continuous.29),
-on the other hand, means that the time of collision is determined very precisely,
-and the user is not restricted to a fixed time-stepping method.
-There are currently two kinds of shapes supported by Collider: circles and rectangles.
-The user specifies the positions and velocities of these shapes, which
-they can update at any time, and Collider will solve for the precise times of
-collision and separation.
+on the other hand, means that the time of collision is determined very
+precisely, and the user is not restricted to a fixed time-stepping method. There
+are currently two kinds of shapes supported by Collider: circles and rectangles.
+The user specifies the positions and velocities of these shapes, which they can
+update at any time, and Collider will solve for the precise times of collision
+and separation.
 
-There are certain advantages that continuous collision detection
-holds over the traditional approach.
-In a game engine, the position of a sprite may be updated to overlap a wall,
-and in a traditional collision system there would need to be a post-correction
-to make sure the sprite does not appear inside of the wall.
-This is not needed with continuous collision detection, since
-the precise time and location at which the sprite touches the wall is known.
-Traditional collision detection may have an issue with "tunneling," in which a
-fast small object runs into a narrow wall and collision detection misses it,
-or two fast small objects fly right through each other and collision detection misses it.
-This is also not a problem for continuous collision detection.
-It is also debatable that continuous collision detection may be
-more efficient in certain circumstances,
-since the hitboxes may be updated less frequently and still maintain a
-smooth appearance over time.
+There are certain advantages that continuous collision detection holds over the
+traditional approach. In a game engine, the position of a sprite may be updated
+to overlap a wall, and in a traditional collision system there would need to be
+a post-correction to make sure the sprite does not appear inside of the wall.
+This is not needed with continuous collision detection, since the precise time
+and location at which the sprite touches the wall is known. Traditional
+collision detection may have an issue with "tunneling," in which a fast small
+object runs into a narrow wall and collision detection misses it, or two fast
+small objects fly right through each other and collision detection misses it.
+This is also not a problem for continuous collision detection. It is also
+debatable that continuous collision detection may be more efficient in certain
+circumstances, since the hitboxes may be updated less frequently and still
+maintain a smooth appearance over time.
 
 ### Example
 ```rust
@@ -98,8 +97,10 @@ License](http://www.apache.org/licenses/LICENSE-2.0.html).
 
 ### Looking forward
 
-(Note: this section is intended for people who have already familiarized themselves with the library.)
+(Note: this section is intended for people who have already familiarized
+(themselves with the library.)
 
-There are a few new features that may be added in the more distant future, or if I receive high demand
+There are a few new features that may be added in the more distant future, or if
+I receive high demand:
 * Adding right-triangles to the set of possible shapes.
   (Note: I do not intend to add general polygons)

--- a/src/core/collider.rs
+++ b/src/core/collider.rs
@@ -12,31 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use fnv::FnvHashMap;
-use std::mem;
-use core::events::{EventManager, EventKey, EventKeysMap, InternalEvent};
-use core::{Hitbox, HbVel, HbId, HIGH_TIME, HbProfile, HbGroup};
-use core::grid::Grid;
 use core::dur_hitbox::DurHitbox;
+use core::events::{EventKey, EventKeysMap, EventManager, InternalEvent};
+use core::grid::Grid;
+use core::{HbGroup, HbId, HbProfile, HbVel, Hitbox, HIGH_TIME};
+use fnv::FnvHashMap;
 use geom::PlacedShape;
+use std::mem;
 use util::TightSet;
 
 // TODO check that floating point values are within a good range when adding/updating hitboxes
 
 /// A structure that tracks hitboxes and returns collide/separate events.
 ///
-/// Collider manages events using a "simulation time" that the user updates as necessary.
-/// This time starts at `0.0`.
+/// Collider manages events using a "simulation time" that the user updates as
+/// necessary. This time starts at `0.0`.
 pub struct Collider<P: HbProfile> {
     hitboxes: FnvHashMap<HbId, HitboxInfo<P>>,
     time: f64,
     grid: Grid,
     padding: f64,
-    events: EventManager
+    events: EventManager,
 }
 
-impl <P: HbProfile> Collider<P> {
-    /// Constructs a new `Collider` instance.
+impl<P: HbProfile> Collider<P> {
+    /// # Constructs a new `Collider` instance.
+    ///
     /// To reduce the number of overlaps that are tested, hitboxes are placed in
     /// a sparse grid structure behind the scenes. `cell_width` is the width of
     /// the cells used in that grid. If your game has a similar grid concept,
@@ -59,11 +60,11 @@ impl <P: HbProfile> Collider<P> {
         assert!(cell_width > padding, "requires cell_width > padding");
         assert!(padding > 0.0, "requires padding > 0.0");
         Collider {
-            hitboxes : FnvHashMap::default(),
-            time : 0.0,
-            grid : Grid::new(cell_width),
+            hitboxes: FnvHashMap::default(),
+            time: 0.0,
+            grid: Grid::new(cell_width),
             padding,
-            events : EventManager::new()
+            events: EventManager::new(),
         }
     }
 
@@ -75,9 +76,10 @@ impl <P: HbProfile> Collider<P> {
     /// Returns the time at which `self.next()` needs to be called again.
     ///
     /// Even if `self.next_time() == self.time()`, there is a chance that
-    /// calling `self.next()` will return `None`, having processed an internal event.
-    /// Regardless, after `self.next()` has been called repeatedly until it
-    /// returns `None`, then `self.next_time()` will be greater than `self.time()` again.
+    /// calling `self.next()` will return `None`, having processed an internal
+    /// event. Regardless, after `self.next()` has been called repeatedly until
+    /// it returns `None`, then `self.next_time()` will be greater than
+    /// `self.time()` again.
     ///
     /// This is a fast constant-time operation.  The result may be infinity.
     pub fn next_time(&self) -> f64 {
@@ -86,9 +88,9 @@ impl <P: HbProfile> Collider<P> {
 
     /// Advances the simulation time to the given value.
     ///
-    /// The positions of all hitboxes will be updated based on the velocities of the hitboxes.
-    /// Will panic if `time` exceeds `self.next_time()`.
-    /// Will also panic if `time` is less than `self.time()` (i.e. cannot rewind time).
+    /// The positions of all hitboxes will be updated based on the velocities of
+    /// the hitboxes. Will panic if `time` exceeds `self.next_time()`. Will also
+    /// panic if `time` is less than `self.time()` (i.e. cannot rewind time).
     ///
     /// The hitboxes are updated implicitly, and this is actually a
     /// fast constant-time operation.
@@ -99,17 +101,23 @@ impl <P: HbProfile> Collider<P> {
         self.time = time;
     }
 
-    /// Processes and returns the next `Collide` or `Separate` event,
-    /// or returns `None` if there are no more events that occured at the given time
-    /// (although an internal event might have been processed if `None` is returned).
-    /// Will always return `None` if `self.next_time() > self.time()`.
+    /// Processes and returns the next `Collide` or `Separate` event, or returns
+    /// `None` if there are no more events that occured at the given time
+    /// (although an internal event might have been processed if `None` is
+    /// returned). Will always return `None` if `self.next_time() >
+    /// self.time()`.
     ///
-    /// The returned value is a tuple, denoting the type of event (`Collide` or `Separate`)
-    /// and the two hitbox profiles involved, in increasing order by `HbId`.
+    /// The returned value is a tuple, denoting the type of event (`Collide` or
+    /// `Separate`) and the two hitbox profiles involved, in increasing order by
+    /// `HbId`.
     pub fn next(&mut self) -> Option<(HbEvent, P, P)> {
         while let Some(event) = self.events.next(self.time, &mut self.hitboxes) {
             if let Some((event, id_1, id_2)) = self.process_event(event) {
-                return Some((event, self.hitboxes[&id_1].profile, self.hitboxes[&id_2].profile));
+                return Some((
+                    event,
+                    self.hitboxes[&id_1].profile,
+                    self.hitboxes[&id_2].profile,
+                ));
             }
         }
         None
@@ -121,33 +129,44 @@ impl <P: HbProfile> Collider<P> {
                 let mut hitbox_info_1 = self.hitboxes.remove(&id_1).unwrap();
                 {
                     let hitbox_info_2 = self.hitboxes.get_mut(&id_2).unwrap();
-                    Collider::process_collision(id_1, &mut hitbox_info_1, id_2, hitbox_info_2,
-                                                &mut self.events, self.time, self.padding);
+                    Collider::process_collision(
+                        id_1,
+                        &mut hitbox_info_1,
+                        id_2,
+                        hitbox_info_2,
+                        &mut self.events,
+                        self.time,
+                        self.padding,
+                    );
                 }
                 assert!(self.hitboxes.insert(id_1, hitbox_info_1).is_none());
                 Some(new_event(HbEvent::Collide, id_1, id_2))
-            },
+            }
             InternalEvent::Separate(id_1, id_2) => {
                 let mut hitbox_info_1 = self.hitboxes.remove(&id_1).unwrap();
                 {
                     let hitbox_info_2 = self.hitboxes.get_mut(&id_2).unwrap();
                     assert!(hitbox_info_1.overlaps.remove(&id_2));
                     assert!(hitbox_info_2.overlaps.remove(&id_1));
-                    let delay = hitbox_info_1.hitbox_at_time(self.time).collide_time(&hitbox_info_2.hitbox_at_time(self.time));
-                    self.events.add_pair_event(self.time + delay, InternalEvent::Collide(id_1, id_2),
-                        &mut hitbox_info_1.event_keys, &mut hitbox_info_2.event_keys);
+                    let delay = hitbox_info_1
+                        .hitbox_at_time(self.time)
+                        .collide_time(&hitbox_info_2.hitbox_at_time(self.time));
+                    self.events.add_pair_event(
+                        self.time + delay,
+                        InternalEvent::Collide(id_1, id_2),
+                        &mut hitbox_info_1.event_keys,
+                        &mut hitbox_info_2.event_keys,
+                    );
                 }
                 assert!(self.hitboxes.insert(id_1, hitbox_info_1).is_none());
                 Some(new_event(HbEvent::Separate, id_1, id_2))
-            },
+            }
             InternalEvent::Reiterate(id) => {
                 self.internal_update_hitbox(id, None);
                 None
-            },
+            }
             #[cfg(debug_assertions)]
-            InternalEvent::PanicSmallHitbox(id) => {
-                panic!("hitbox {} became too small", id)
-            },
+            InternalEvent::PanicSmallHitbox(id) => panic!("hitbox {} became too small", id),
             #[cfg(debug_assertions)]
             InternalEvent::PanicDurationPassed(id) => {
                 panic!("hitbox {} was not updated before duration passed", id)
@@ -155,13 +174,26 @@ impl <P: HbProfile> Collider<P> {
         }
     }
 
-    fn process_collision(id_1: HbId, hb_1: &mut HitboxInfo<P>, id_2: HbId, hb_2: &mut HitboxInfo<P>,
-                         events: &mut EventManager, time: f64, padding: f64) {
+    fn process_collision(
+        id_1: HbId,
+        hb_1: &mut HitboxInfo<P>,
+        id_2: HbId,
+        hb_2: &mut HitboxInfo<P>,
+        events: &mut EventManager,
+        time: f64,
+        padding: f64,
+    ) {
         assert!(hb_1.overlaps.insert(id_2));
         assert!(hb_2.overlaps.insert(id_1));
-        let delay = hb_1.hitbox_at_time(time).separate_time(&hb_2.hitbox_at_time(time), padding);
-        events.add_pair_event(time + delay, InternalEvent::Separate(id_1, id_2),
-                              &mut hb_1.event_keys, &mut hb_2.event_keys);
+        let delay = hb_1
+            .hitbox_at_time(time)
+            .separate_time(&hb_2.hitbox_at_time(time), padding);
+        events.add_pair_event(
+            time + delay,
+            InternalEvent::Separate(id_1, id_2),
+            &mut hb_1.event_keys,
+            &mut hb_2.event_keys,
+        );
     }
 
     /// Returns the current state of the hitbox with the given `id`.
@@ -169,16 +201,16 @@ impl <P: HbProfile> Collider<P> {
         self.hitboxes[&id].pub_hitbox_at_time(self.time)
     }
 
-    /// Adds a new hitbox to the collider.
+    /// # Adds a new hitbox to the collider.
     ///
-    /// The `profile` is used to track the hitbox over time;
-    /// Collider will return this profile in certain methods,
-    /// and the ID in this profile can be used to make updates to the hitbox.
-    /// This method will panic if there is an ID clash.
-    /// `hitbox` is the initial state of the hitbox.
+    /// The `profile` is used to track the hitbox over time; Collider will
+    /// return this profile in certain methods, and the ID in this profile can
+    /// be used to make updates to the hitbox. This method will panic if there
+    /// is an ID clash. `hitbox` is the initial state of the hitbox.
     ///
-    /// Returns a vector of all hitbox profiles that this new hitbox collided with as it was added.
-    /// Note that separate collision events will not be generated for these collisions.
+    /// Returns a vector of all hitbox profiles that this new hitbox collided
+    /// with as it was added. Note that separate collision events will not be
+    /// generated for these collisions.
     pub fn add_hitbox(&mut self, profile: P, hitbox: Hitbox) -> Vec<P> {
         hitbox.validate(self.padding, self.time);
         let id = profile.id();
@@ -197,7 +229,10 @@ impl <P: HbProfile> Collider<P> {
     }
 
     fn internal_update_hitbox(&mut self, id: HbId, vel: Option<HbVel>) {
-        let mut info = self.hitboxes.remove(&id).unwrap_or_else(|| panic!("hitbox id {} not found", id));
+        let mut info = self
+            .hitboxes
+            .remove(&id)
+            .unwrap_or_else(|| panic!("hitbox id {} not found", id));
         let old_hitbox = info.hitbox.to_dur_hitbox(info.start_time);
         info.hitbox = info.pub_hitbox_at_time(self.time);
         if let Some(vel) = vel {
@@ -206,7 +241,8 @@ impl <P: HbProfile> Collider<P> {
         }
         info.start_time = self.time;
         let has_group = info.profile.group().is_some();
-        self.events.clear_related_events(id, &mut info.event_keys, &mut self.hitboxes);
+        self.events
+            .clear_related_events(id, &mut info.event_keys, &mut self.hitboxes);
         self.solitaire_event_check(id, &mut info, has_group);
         let new_hitbox = info.hitbox.to_dur_hitbox(self.time);
         let result = self.update_hitbox_tracking(id, info, Some(old_hitbox), new_hitbox);
@@ -215,59 +251,94 @@ impl <P: HbProfile> Collider<P> {
 
     /// Removes the hitbox with the given `id` from all tracking.
     ///
-    /// Returns a vector of all hitbox profiles that this hitbox separated from as it was removed.
-    /// No further events will be generated for this hitbox.
+    /// Returns a vector of all hitbox profiles that this hitbox separated from
+    /// as it was removed. No further events will be generated for this hitbox.
     pub fn remove_hitbox(&mut self, id: HbId) -> Vec<P> {
-        let mut info = self.hitboxes.remove(&id).unwrap_or_else(|| panic!("hitbox id {} not found", id));
-        self.events.clear_related_events(id, &mut info.event_keys, &mut self.hitboxes);
+        let mut info = self
+            .hitboxes
+            .remove(&id)
+            .unwrap_or_else(|| panic!("hitbox id {} not found", id));
+        self.events
+            .clear_related_events(id, &mut info.event_keys, &mut self.hitboxes);
         if let Some(group) = info.profile.group() {
             let info_start_time = info.start_time;
             let empty_group_array: &[HbGroup] = &[];
             self.grid.update_hitbox(
-                id, group, Some(&info.hitbox.to_dur_hitbox(info_start_time)), None, empty_group_array
+                id,
+                group,
+                Some(&info.hitbox.to_dur_hitbox(info_start_time)),
+                None,
+                empty_group_array,
             );
         }
         self.clear_overlaps(id, &mut info)
     }
 
-    /// Returns the profiles of all currently tracked overlaps on the hitbox with the given `id`.
+    /// Returns the profiles of all currently tracked overlaps on the hitbox
+    /// with the given `id`.
     pub fn get_overlaps(&self, id: HbId) -> Vec<P> {
-        let info = self.hitboxes.get(&id).unwrap_or_else(|| panic!("hitbox id {} not found", id));
-        info.overlaps.iter()
-                     .map(|other_id| self.hitboxes[other_id].profile)
-                     .collect()
+        let info = self
+            .hitboxes
+            .get(&id)
+            .unwrap_or_else(|| panic!("hitbox id {} not found", id));
+        info.overlaps
+            .iter()
+            .map(|other_id| self.hitboxes[other_id].profile)
+            .collect()
     }
 
-    /// Returns true if there is a currently tracked overlap between the hitboxes with `id_1` and `id_2`.
+    /// Returns true if there is a currently tracked overlap between the
+    /// hitboxes with `id_1` and `id_2`.
     pub fn is_overlapping(&self, id_1: HbId, id_2: HbId) -> bool {
-        self.hitboxes.get(&id_1)
-                     .map(|info| info.overlaps.contains(&id_2))
-                     .unwrap_or(false)
+        self.hitboxes
+            .get(&id_1)
+            .map(|info| info.overlaps.contains(&id_2))
+            .unwrap_or(false)
     }
 
-    /// Returns the profiles of all hitboxes that overlap the given `shape` and interact with the given `profile`.
+    /// Returns the profiles of all hitboxes that overlap the given `shape` and
+    /// interact with the given `profile`.
     pub fn query_overlaps(&self, shape: &PlacedShape, profile: &P) -> Vec<P> {
-        self.grid.shape_cellmates(shape, profile.interact_groups()).iter()
-                 .map(|id| &self.hitboxes[id])
-                 .filter(|info| info.profile.can_interact(profile))
-                 .filter(|info| info.pub_hitbox_at_time(self.time).value.overlaps(shape))
-                 .map(|info| info.profile)
-                 .collect()
+        self.grid
+            .shape_cellmates(shape, profile.interact_groups())
+            .iter()
+            .map(|id| &self.hitboxes[id])
+            .filter(|info| info.profile.can_interact(profile))
+            .filter(|info| info.pub_hitbox_at_time(self.time).value.overlaps(shape))
+            .map(|info| info.profile)
+            .collect()
     }
 
-    fn update_hitbox_tracking(&mut self, id: HbId, mut info: HitboxInfo<P>, old_hitbox: Option<DurHitbox>,
-                              new_hitbox: DurHitbox) -> Vec<P> {
+    fn update_hitbox_tracking(
+        &mut self,
+        id: HbId,
+        mut info: HitboxInfo<P>,
+        old_hitbox: Option<DurHitbox>,
+        new_hitbox: DurHitbox,
+    ) -> Vec<P> {
         let mut result = Vec::new();
         if let Some(group) = info.profile.group() {
             for &other_id in info.overlaps.clone().iter() {
                 let other_info = self.hitboxes.get_mut(&other_id).unwrap();
-                let delay = new_hitbox.separate_time(&other_info.hitbox_at_time(self.time), self.padding);
-                self.events.add_pair_event(self.time + delay, InternalEvent::Separate(id, other_id),
-                    &mut info.event_keys, &mut other_info.event_keys);
+                let delay =
+                    new_hitbox.separate_time(&other_info.hitbox_at_time(self.time), self.padding);
+                self.events.add_pair_event(
+                    self.time + delay,
+                    InternalEvent::Separate(id, other_id),
+                    &mut info.event_keys,
+                    &mut other_info.event_keys,
+                );
             }
-            let test_ids = self.grid.update_hitbox(
-                id, group, old_hitbox.as_ref(), Some(&new_hitbox), info.profile.interact_groups()
-            ).unwrap();
+            let test_ids = self
+                .grid
+                .update_hitbox(
+                    id,
+                    group,
+                    old_hitbox.as_ref(),
+                    Some(&new_hitbox),
+                    info.profile.interact_groups(),
+                )
+                .unwrap();
             for other_id in test_ids {
                 if old_hitbox.is_none() || !info.overlaps.contains(&other_id) {
                     let other_info = self.hitboxes.get_mut(&other_id).unwrap();
@@ -275,11 +346,22 @@ impl <P: HbProfile> Collider<P> {
                         let delay = new_hitbox.collide_time(&other_info.hitbox_at_time(self.time));
                         if old_hitbox.is_none() && delay == 0.0 {
                             result.push(other_info.profile);
-                            Collider::process_collision(id, &mut info, other_id, other_info,
-                                                        &mut self.events, self.time, self.padding);
+                            Collider::process_collision(
+                                id,
+                                &mut info,
+                                other_id,
+                                other_info,
+                                &mut self.events,
+                                self.time,
+                                self.padding,
+                            );
                         } else {
-                            self.events.add_pair_event(self.time + delay, InternalEvent::Collide(id, other_id),
-                                &mut info.event_keys, &mut other_info.event_keys);
+                            self.events.add_pair_event(
+                                self.time + delay,
+                                InternalEvent::Collide(id, other_id),
+                                &mut info.event_keys,
+                                &mut other_info.event_keys,
+                            );
                         }
                     }
                 }
@@ -291,40 +373,74 @@ impl <P: HbProfile> Collider<P> {
     }
 
     fn clear_overlaps(&mut self, id: HbId, hitbox_info: &mut HitboxInfo<P>) -> Vec<P> {
-        hitbox_info.overlaps.drain().map(|other_id| {
-            let other_hitbox_info = self.hitboxes.get_mut(&other_id).unwrap();
-            assert!(other_hitbox_info.overlaps.remove(&id));
-            other_hitbox_info.profile
-        }).collect()
+        hitbox_info
+            .overlaps
+            .drain()
+            .map(|other_id| {
+                let other_hitbox_info = self.hitboxes.get_mut(&other_id).unwrap();
+                assert!(other_hitbox_info.overlaps.remove(&id));
+                other_hitbox_info.profile
+            })
+            .collect()
     }
 
     #[cfg(debug_assertions)]
-    fn solitaire_event_check(&mut self, id: HbId, hitbox_info: &mut HitboxInfo<P>, has_group: bool) {
+    fn solitaire_event_check(
+        &mut self,
+        id: HbId,
+        hitbox_info: &mut HitboxInfo<P>,
+        has_group: bool,
+    ) {
         hitbox_info.pub_end_time = hitbox_info.hitbox.vel.end_time;
-        let mut result = (self.time + self.grid.cell_period(&hitbox_info.hitbox, has_group), InternalEvent::Reiterate(id));
+        let mut result = (
+            self.time + self.grid.cell_period(&hitbox_info.hitbox, has_group),
+            InternalEvent::Reiterate(id),
+        );
         let end_time = hitbox_info.hitbox.vel.end_time;
-        if end_time < result.0 { result = (end_time, InternalEvent::PanicDurationPassed(id)); }
+        if end_time < result.0 {
+            result = (end_time, InternalEvent::PanicDurationPassed(id));
+        }
         let end_time = self.time + hitbox_info.hitbox.time_until_too_small(self.padding);
-        if end_time < result.0 { result = (end_time, InternalEvent::PanicSmallHitbox(id)); }
+        if end_time < result.0 {
+            result = (end_time, InternalEvent::PanicSmallHitbox(id));
+        }
         hitbox_info.hitbox.vel.end_time = result.0;
-        self.events.add_solitaire_event(result.0, result.1, &mut hitbox_info.event_keys);
+        self.events
+            .add_solitaire_event(result.0, result.1, &mut hitbox_info.event_keys);
     }
 
     #[cfg(not(debug_assertions))]
-    fn solitaire_event_check(&mut self, id: HbId, hitbox_info: &mut HitboxInfo<P>, has_group: bool) {
+    fn solitaire_event_check(
+        &mut self,
+        id: HbId,
+        hitbox_info: &mut HitboxInfo<P>,
+        has_group: bool,
+    ) {
         hitbox_info.pub_end_time = hitbox_info.hitbox.vel.end_time;
-        let mut result = (self.time + self.grid.cell_period(&hitbox_info.hitbox, has_group), true);
+        let mut result = (
+            self.time + self.grid.cell_period(&hitbox_info.hitbox, has_group),
+            true,
+        );
         let end_time = hitbox_info.hitbox.vel.end_time;
-        if end_time < result.0 { result = (end_time, false); }
+        if end_time < result.0 {
+            result = (end_time, false);
+        }
         let end_time = self.time + hitbox_info.hitbox.time_until_too_small(self.padding);
-        if end_time < result.0 { result = (end_time, false); }
+        if end_time < result.0 {
+            result = (end_time, false);
+        }
         hitbox_info.hitbox.vel.end_time = result.0;
-        if result.1 { self.events.add_solitaire_event(result.0, InternalEvent::Reiterate(id), &mut hitbox_info.event_keys); }
+        if result.1 {
+            self.events.add_solitaire_event(
+                result.0,
+                InternalEvent::Reiterate(id),
+                &mut hitbox_info.event_keys,
+            );
+        }
     }
 }
 
-
-impl <P: HbProfile> EventKeysMap for FnvHashMap<HbId, HitboxInfo<P>> {
+impl<P: HbProfile> EventKeysMap for FnvHashMap<HbId, HitboxInfo<P>> {
     fn event_keys_mut(&mut self, id: HbId) -> &mut TightSet<EventKey> {
         &mut self.get_mut(&id).unwrap().event_keys
     }
@@ -336,10 +452,10 @@ struct HitboxInfo<P: HbProfile> {
     start_time: f64,
     pub_end_time: f64,
     event_keys: TightSet<EventKey>,
-    overlaps: TightSet<HbId>
+    overlaps: TightSet<HbId>,
 }
 
-impl <P: HbProfile> HitboxInfo<P> {
+impl<P: HbProfile> HitboxInfo<P> {
     fn new(hitbox: Hitbox, profile: P, start_time: f64) -> HitboxInfo<P> {
         HitboxInfo {
             profile,
@@ -347,19 +463,25 @@ impl <P: HbProfile> HitboxInfo<P> {
             hitbox,
             start_time,
             event_keys: TightSet::new(),
-            overlaps: TightSet::new()
+            overlaps: TightSet::new(),
         }
     }
 
     fn hitbox_at_time(&self, time: f64) -> DurHitbox {
-        assert!(time >= self.start_time && time <= self.hitbox.vel.end_time, "invalid time");
+        assert!(
+            time >= self.start_time && time <= self.hitbox.vel.end_time,
+            "invalid time"
+        );
         let mut result = self.hitbox.clone();
         result.value = result.advanced_shape(time - self.start_time);
         result.to_dur_hitbox(time)
     }
 
     fn pub_hitbox_at_time(&self, time: f64) -> Hitbox {
-        assert!(time >= self.start_time && time <= self.pub_end_time, "invalid time");
+        assert!(
+            time >= self.start_time && time <= self.pub_end_time,
+            "invalid time"
+        );
         let mut result = self.hitbox.clone();
         result.vel.end_time = self.pub_end_time;
         result.value = result.advanced_shape(time - self.start_time);
@@ -375,13 +497,15 @@ pub enum HbEvent {
 
     /// Occurs when two hitboxes separate.
     ///
-    /// A second `Collide` betweent two hitboxes may not occur before a `Separate`.
-    /// A `Separate` event must come after a `Collide` event.
-    Separate
+    /// A second `Collide` between two hitboxes may not occur before a
+    /// `Separate`. A `Separate` event must come after a `Collide` event.
+    Separate,
 }
 
 fn new_event(event: HbEvent, mut id_1: HbId, mut id_2: HbId) -> (HbEvent, HbId, HbId) {
     assert!(id_1 != id_2, "ids must be different: {} {}", id_1, id_2);
-    if id_1 > id_2 { mem::swap(&mut id_1, &mut id_2); }
+    if id_1 > id_2 {
+        mem::swap(&mut id_1, &mut id_2);
+    }
     (event, id_1, id_2)
 }

--- a/src/core/dur_hitbox/mod.rs
+++ b/src/core/dur_hitbox/mod.rs
@@ -14,10 +14,10 @@
 
 mod solvers;
 
-use std::f64;
-use geom::*;
-use geom::shape::PlacedBounds;
 use core;
+use geom::shape::PlacedBounds;
+use geom::*;
+use std::f64;
 
 // DurHitbox (and DurHbVel) is almost identical to Hitbox (and HbVel), except
 // it uses a `duration` (amount of time until invalidation of the hitbox)
@@ -54,8 +54,12 @@ impl DurHbVel {
 }
 
 impl PlacedBounds for DurHbVel {
-    fn bounds_center(&self) -> &Vec2 { &self.value }
-    fn bounds_dims(&self) -> &Vec2 { &self.resize }
+    fn bounds_center(&self) -> &Vec2 {
+        &self.value
+    }
+    fn bounds_dims(&self) -> &Vec2 {
+        &self.resize
+    }
 }
 
 #[derive(Clone)]
@@ -66,11 +70,18 @@ pub struct DurHitbox {
 
 impl DurHitbox {
     pub fn new(value: PlacedShape) -> DurHitbox {
-        DurHitbox { value, vel: DurHbVel::still() }
+        DurHitbox {
+            value,
+            vel: DurHbVel::still(),
+        }
     }
 
     pub fn advanced_shape(&self, time: f64) -> PlacedShape {
-        assert!(time < core::HIGH_TIME, "requires time < {}", core::HIGH_TIME);
+        assert!(
+            time < core::HIGH_TIME,
+            "requires time < {}",
+            core::HIGH_TIME
+        );
         self.value.advance(self.vel.value, self.vel.resize, time)
     }
 
@@ -98,8 +109,8 @@ impl DurHitbox {
 
 #[cfg(test)]
 mod tests {
-    use geom::*;
     use core::dur_hitbox::DurHitbox;
+    use geom::*;
     use std::f64;
 
     #[test]
@@ -119,10 +130,13 @@ mod tests {
     #[test]
     fn test_circle_circle_collision() {
         let sqrt2 = (2.0f64).sqrt();
-        let mut a = DurHitbox::new(PlacedShape::new(v2(-0.1*sqrt2, 0.0), Shape::circle(2.0)));
+        let mut a = DurHitbox::new(PlacedShape::new(v2(-0.1 * sqrt2, 0.0), Shape::circle(2.0)));
         a.vel.value = v2(0.1, 0.0);
         a.vel.duration = 100.0;
-        let mut b = DurHitbox::new(PlacedShape::new(v2(3.0*sqrt2, 0.0), Shape::circle(2.0 + sqrt2*0.1)));
+        let mut b = DurHitbox::new(PlacedShape::new(
+            v2(3.0 * sqrt2, 0.0),
+            Shape::circle(2.0 + sqrt2 * 0.1),
+        ));
         b.vel.value = v2(-2.0, 1.0);
         b.vel.resize = v2(-0.1, -0.1);
         b.vel.duration = 100.0;

--- a/src/core/dur_hitbox/solvers.rs
+++ b/src/core/dur_hitbox/solvers.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::f64;
 use core;
 use core::dur_hitbox::DurHitbox;
-use geom::*;
 use geom::shape::PlacedBounds;
+use geom::*;
+use std::f64;
 use util;
 
 // This module contains methods to solve for the collision/separation time
@@ -24,7 +24,9 @@ use util;
 
 pub fn collide_time(a: &DurHitbox, b: &DurHitbox) -> f64 {
     let duration = a.vel.duration.min(b.vel.duration);
-    if a.bounding_box_for(duration).overlaps(&b.bounding_box_for(duration)) {
+    if a.bounding_box_for(duration)
+        .overlaps(&b.bounding_box_for(duration))
+    {
         time_unpadded(a, b, true, duration)
     } else {
         f64::INFINITY
@@ -34,7 +36,7 @@ pub fn collide_time(a: &DurHitbox, b: &DurHitbox) -> f64 {
 pub fn separate_time(a: &DurHitbox, b: &DurHitbox, padding: f64) -> f64 {
     let (a, b) = match (a.value.kind(), b.value.kind()) {
         (ShapeKind::Rect, ShapeKind::Circle) => (b, a),
-        _ => (a, b)
+        _ => (a, b),
     };
     let mut a = a.clone();
     a.value.shape = Shape::new(a.value.kind(), a.value.dims() + v2(padding, padding) * 2.0);
@@ -46,9 +48,13 @@ fn time_unpadded(a: &DurHitbox, b: &DurHitbox, for_collide: bool, duration: f64)
         (ShapeKind::Rect, ShapeKind::Rect) => rect_rect_time(a, b, for_collide),
         (ShapeKind::Circle, ShapeKind::Circle) => circle_circle_time(a, b, for_collide),
         (ShapeKind::Rect, ShapeKind::Circle) => rect_circle_time(a, b, for_collide, duration),
-        (ShapeKind::Circle, ShapeKind::Rect) => rect_circle_time(b, a, for_collide, duration)
+        (ShapeKind::Circle, ShapeKind::Rect) => rect_circle_time(b, a, for_collide, duration),
     };
-    if result >= duration { f64::INFINITY } else { result }
+    if result >= duration {
+        f64::INFINITY
+    } else {
+        result
+    }
 }
 
 fn rect_rect_time(a: &DurHitbox, b: &DurHitbox, for_collide: bool) -> f64 {
@@ -72,7 +78,11 @@ fn rect_rect_time(a: &DurHitbox, b: &DurHitbox, for_collide: bool) -> f64 {
             return if for_collide { f64::INFINITY } else { 0.0 };
         }
     }
-    if for_collide { overlap_start } else { overlap_end }
+    if for_collide {
+        overlap_start
+    } else {
+        overlap_end
+    }
 }
 
 fn circle_circle_time(a: &DurHitbox, b: &DurHitbox, for_collide: bool) -> f64 {
@@ -82,7 +92,9 @@ fn circle_circle_time(a: &DurHitbox, b: &DurHitbox, for_collide: bool) -> f64 {
     let dist = a.value.pos - b.value.pos;
 
     let coeff_c = sign * (net_rad * net_rad - dist.len_sq());
-    if coeff_c > 0.0 { return 0.0; }
+    if coeff_c > 0.0 {
+        return 0.0;
+    }
 
     let net_rad_vel = (a.vel.resize.x + b.vel.resize.x) * 0.5;
     let dist_vel = a.vel.value - b.vel.value;
@@ -92,7 +104,7 @@ fn circle_circle_time(a: &DurHitbox, b: &DurHitbox, for_collide: bool) -> f64 {
 
     match util::quad_root_ascending(coeff_a, coeff_b, coeff_c) {
         Some(result) if result >= 0.0 => result,
-        _ => f64::INFINITY
+        _ => f64::INFINITY,
     }
 }
 
@@ -120,8 +132,12 @@ fn rect_circle_collide_time(rect: &DurHitbox, circle: &DurHitbox, duration: f64)
 
 fn rect_circle_separate_time(rect: &DurHitbox, circle: &DurHitbox) -> f64 {
     let base_time = rect_rect_time(rect, circle, false);
-    if base_time == 0.0 { return 0.0 }
-    if base_time >= core::HIGH_TIME { return f64::INFINITY }
+    if base_time == 0.0 {
+        return 0.0;
+    }
+    if base_time >= core::HIGH_TIME {
+        return f64::INFINITY;
+    }
 
     let mut rect = rect.clone();
     rect.value = rect.advanced_shape(base_time);
@@ -137,7 +153,10 @@ fn rect_circle_separate_time(rect: &DurHitbox, circle: &DurHitbox) -> f64 {
 fn rebased_rect_circle_collide_time(rect: &DurHitbox, circle: &DurHitbox) -> f64 {
     let sector = rect.value.sector(circle.value.pos);
     if sector.is_corner() {
-        let mut corner = DurHitbox::new(PlacedShape::new(rect.value.corner(sector), Shape::circle(0.0)));
+        let mut corner = DurHitbox::new(PlacedShape::new(
+            rect.value.corner(sector),
+            Shape::circle(0.0),
+        ));
         corner.vel.value = rect.vel.corner(sector);
         circle_circle_time(&corner, circle, true)
     } else {

--- a/src/core/events.rs
+++ b/src/core/events.rs
@@ -59,7 +59,7 @@ impl PartialOrd for EventKey {
 
 impl Ord for EventKey {
     fn cmp(&self, other: &Self) -> Ordering {
-        if (self.time - other.time).abs() < std::f64::EPSILON {
+        if self.time == other.time {
             self.index.cmp(&other.index)
         } else {
             n64(self.time).cmp(&n64(other.time))
@@ -174,7 +174,7 @@ impl EventManager {
 
     pub fn next<M: EventKeysMap>(&mut self, time: f64, map: &mut M) -> Option<InternalEvent> {
         if let Some(key) = self.peek_key() {
-            if (key.time() - time).abs() < std::f64::EPSILON {
+            if key.time() == time {
                 let event = self.events.remove(&key).unwrap();
                 for id in event.involved_hitbox_ids().iter() {
                     assert!(map.event_keys_mut(id).remove(&key));

--- a/src/core/grid.rs
+++ b/src/core/grid.rs
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::f64;
-use std::collections::hash_map;
-use fnv::{FnvHashMap, FnvHashSet};
-use std::cmp;
-use core::{HbId, Hitbox, HbGroup};
 use core::dur_hitbox::DurHitbox;
-use util::TightSet;
+use core::{HbGroup, HbId, Hitbox};
+use fnv::{FnvHashMap, FnvHashSet};
+use geom::shape::{PlacedBounds, PlacedShape};
 use index_rect::IndexRect;
-use geom::shape::{PlacedShape, PlacedBounds};
+use std::cmp;
+use std::collections::hash_map;
+use std::f64;
+use util::TightSet;
 
 // Grid is a sparse 2D grid implemented as a HashMap. This is used as the
 // pruning method to decide which hitboxes to check for collisions.
@@ -30,13 +30,13 @@ use geom::shape::{PlacedShape, PlacedBounds};
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 struct GridKey {
     coord: (i32, i32),
-    group: HbGroup
+    group: HbGroup,
 }
 
 #[derive(Copy, Clone)]
 struct GridArea {
     rect: IndexRect,
-    group: HbGroup
+    group: HbGroup,
 }
 
 impl GridArea {
@@ -47,12 +47,15 @@ impl GridArea {
 
 pub struct Grid {
     map: FnvHashMap<GridKey, TightSet<HbId>>,
-    cell_width: f64
+    cell_width: f64,
 }
 
 impl Grid {
     pub fn new(cell_width: f64) -> Grid {
-        Grid { map : FnvHashMap::default(), cell_width }
+        Grid {
+            map: FnvHashMap::default(),
+            cell_width,
+        }
     }
 
     pub fn cell_period(&self, hitbox: &Hitbox, has_group: bool) -> f64 {
@@ -73,9 +76,14 @@ impl Grid {
         self.overlapping_ids(None, bounds, groups)
     }
 
-    pub fn update_hitbox(&mut self, hitbox_id: HbId, group: HbGroup, old_hitbox: Option<&DurHitbox>,
-                         new_hitbox: Option<&DurHitbox>, groups: &[HbGroup]) -> Option<FnvHashSet<HbId>>
-    {
+    pub fn update_hitbox(
+        &mut self,
+        hitbox_id: HbId,
+        group: HbGroup,
+        old_hitbox: Option<&DurHitbox>,
+        new_hitbox: Option<&DurHitbox>,
+        groups: &[HbGroup],
+    ) -> Option<FnvHashSet<HbId>> {
         assert!(new_hitbox.is_some() || groups.is_empty());
         let old_area = old_hitbox.map(|old_hitbox| self.grid_area(old_hitbox, group));
         let new_area = new_hitbox.map(|new_hitbox| self.grid_area(new_hitbox, group));
@@ -84,25 +92,41 @@ impl Grid {
     }
 
     fn grid_area(&self, hitbox: &DurHitbox, group: HbGroup) -> GridArea {
-        GridArea { rect: self.index_bounds(&hitbox.bounding_box()), group }
+        GridArea {
+            rect: self.index_bounds(&hitbox.bounding_box()),
+            group,
+        }
     }
 
     fn index_bounds(&self, bounds: &PlacedShape) -> IndexRect {
         let start_x = (bounds.min_x() / self.cell_width).floor() as i32;
         let start_y = (bounds.min_y() / self.cell_width).floor() as i32;
-        let end_x = cmp::max((bounds.max_x() / self.cell_width).ceil() as i32, start_x + 1);
-        let end_y = cmp::max((bounds.max_y() / self.cell_width).ceil() as i32, start_y + 1);
+        let end_x = cmp::max(
+            (bounds.max_x() / self.cell_width).ceil() as i32,
+            start_x + 1,
+        );
+        let end_y = cmp::max(
+            (bounds.max_y() / self.cell_width).ceil() as i32,
+            start_y + 1,
+        );
         IndexRect::new((start_x, start_y), (end_x, end_y))
     }
 
-    fn overlapping_ids(&self, hitbox_id: Option<HbId>, rect: IndexRect, groups: &[HbGroup]) -> FnvHashSet<HbId> {
+    fn overlapping_ids(
+        &self,
+        hitbox_id: Option<HbId>,
+        rect: IndexRect,
+        groups: &[HbGroup],
+    ) -> FnvHashSet<HbId> {
         let mut result = FnvHashSet::default();
         for &group in groups {
             for coord in rect.iter() {
                 let key = GridKey { coord, group };
                 if let Some(other_ids) = self.map.get(&key) {
                     for &other_id in other_ids.iter() {
-                        if Some(other_id) != hitbox_id { result.insert(other_id); }
+                        if Some(other_id) != hitbox_id {
+                            result.insert(other_id);
+                        }
                     }
                 }
             }
@@ -110,15 +134,25 @@ impl Grid {
         result
     }
 
-    fn update_area(&mut self, hitbox_id: HbId, old_area: Option<GridArea>, new_area: Option<GridArea>) {
+    fn update_area(
+        &mut self,
+        hitbox_id: HbId,
+        old_area: Option<GridArea>,
+        new_area: Option<GridArea>,
+    ) {
         if let Some(old_area) = old_area {
             for coord in old_area.rect.iter() {
-                let key = GridKey { coord, group : old_area.group };
+                let key = GridKey {
+                    coord,
+                    group: old_area.group,
+                };
                 if new_area.map_or(true, |new_area| !new_area.contains(key)) {
                     if let hash_map::Entry::Occupied(mut entry) = self.map.entry(key) {
                         let success = entry.get_mut().remove(&hitbox_id);
                         assert!(success);
-                        if entry.get().is_empty() { entry.remove(); }
+                        if entry.get().is_empty() {
+                            entry.remove();
+                        }
                     } else {
                         unreachable!();
                     }
@@ -127,11 +161,14 @@ impl Grid {
         }
         if let Some(new_area) = new_area {
             for coord in new_area.rect.iter() {
-                let key = GridKey { coord, group : new_area.group };
+                let key = GridKey {
+                    coord,
+                    group: new_area.group,
+                };
                 if old_area.map_or(true, |old_area| !old_area.contains(key)) {
-                   let other_ids = self.map.entry(key).or_insert_with(|| TightSet::new());
-                   let success = other_ids.insert(hitbox_id);
-                   assert!(success);
+                    let other_ids = self.map.entry(key).or_insert_with(|| TightSet::new());
+                    let success = other_ids.insert(hitbox_id);
+                    assert!(success);
                 }
             }
         }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -149,7 +149,10 @@ impl Hitbox {
             "end time must exceed present time"
         );
         if self.value.kind() == ShapeKind::Circle {
-            assert_eq!(self.vel.resize.x, self.vel.resize.y, "circle resize velocity must maintain aspect ratio");
+            assert_eq!(
+                self.vel.resize.x, self.vel.resize.y,
+                "circle resize velocity must maintain aspect ratio"
+            );
         }
         assert!(
             self.value.dims().x >= min_size && self.value.dims().y >= min_size,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -149,10 +149,7 @@ impl Hitbox {
             "end time must exceed present time"
         );
         if self.value.kind() == ShapeKind::Circle {
-            assert!(
-                (self.vel.resize.x - self.vel.resize.y).abs() < std::f64::EPSILON,
-                "circle resize velocity must maintain aspect ratio"
-            );
+            assert_eq!(self.vel.resize.x, self.vel.resize.y, "circle resize velocity must maintain aspect ratio");
         }
         assert!(
             self.value.dims().x >= min_size && self.value.dims().y >= min_size,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod grid;
 mod collider;
-mod events;
 mod dur_hitbox;
+mod events;
+mod grid;
 
 pub use self::collider::*;
 
 use std::f64;
 
-use geom::*;
+use self::dur_hitbox::{DurHbVel, DurHitbox};
 use geom::shape::PlacedBounds;
-use self::dur_hitbox::{DurHitbox, DurHbVel};
+use geom::*;
 
 const HIGH_TIME: f64 = 1e50;
 
@@ -38,20 +38,23 @@ pub struct HbVel {
 
     /// A velocity describing how the hitbox dims are changing over time.
     ///
-    /// Since the width and height of the shape is greater than `padding` at all times,
-    /// if a resize velocity is set that decreases the dimensions of the shape over time,
-    /// then the user is responsible for ensuring that the shape will not decrease below this threshold.
-    /// Collider may panic if this is violated.
+    /// Since the width and height of the shape is greater than `padding` at all
+    /// times, if a resize velocity is set that decreases the dimensions of the
+    /// shape over time, then the user is responsible for ensuring that the
+    /// shape will not decrease below this threshold. Collider may panic if this
+    /// is violated.
     pub resize: Vec2,
 
-    /// An upper-bound on the time at which the hitbox will be updated by the user.
+    /// An upper-bound on the time at which the hitbox will be updated by the
+    /// user.
     ///
-    /// This is an advanced feature for efficiency and does not impact the results.
-    /// Infinity is used as the default, but using a lower value may improve performance
+    /// This is an advanced feature for efficiency and does not impact the
+    /// results. Infinity is used as the default, but using a lower value may
+    /// improve performance
     ///
-    /// Collider will panic if the end time is exceeded without update,
-    /// at least in unoptimized builds.  It is ultimately the user's responsibility
-    /// to ensure that end times are not exceeded.
+    /// Collider will panic if the end time is exceeded without update, at least
+    /// in unoptimized builds.  It is ultimately the user's responsibility to
+    /// ensure that end times are not exceeded.
     pub end_time: f64,
 }
 
@@ -59,35 +62,57 @@ impl HbVel {
     /// Creates an `HbVel` with the given `value`.
     #[inline]
     pub fn moving(value: Vec2) -> HbVel {
-        HbVel { value, resize: Vec2::zero(), end_time: f64::INFINITY }
+        HbVel {
+            value,
+            resize: Vec2::zero(),
+            end_time: f64::INFINITY,
+        }
     }
 
     /// Creates an `HbVel` with the given `value` and `end_time`.
     #[inline]
     pub fn moving_until(value: Vec2, end_time: f64) -> HbVel {
-        HbVel { value, resize: Vec2::zero(), end_time }
+        HbVel {
+            value,
+            resize: Vec2::zero(),
+            end_time,
+        }
     }
 
     /// Creates a stationary `HbVel`.
     #[inline]
     pub fn still() -> HbVel {
-        HbVel { value: Vec2::zero(), resize: Vec2::zero(), end_time: f64::INFINITY }
+        HbVel {
+            value: Vec2::zero(),
+            resize: Vec2::zero(),
+            end_time: f64::INFINITY,
+        }
     }
 
     /// Creates a stationary `HbVel` with the given `end_time`.
     #[inline]
     pub fn still_until(end_time: f64) -> HbVel {
-        HbVel { value: Vec2::zero(), resize: Vec2::zero(), end_time }
+        HbVel {
+            value: Vec2::zero(),
+            resize: Vec2::zero(),
+            end_time,
+        }
     }
 }
 
 impl From<Vec2> for HbVel {
-    fn from(value: Vec2) -> HbVel { HbVel::moving(value) }
+    fn from(value: Vec2) -> HbVel {
+        HbVel::moving(value)
+    }
 }
 
 impl PlacedBounds for HbVel {
-    fn bounds_center(&self) -> &Vec2 { &self.value }
-    fn bounds_dims(&self) -> &Vec2 { &self.resize }
+    fn bounds_center(&self) -> &Vec2 {
+        &self.value
+    }
+    fn bounds_dims(&self) -> &Vec2 {
+        &self.resize
+    }
 }
 
 /// Represents a moving shape for continuous collision testing.
@@ -95,10 +120,12 @@ impl PlacedBounds for HbVel {
 pub struct Hitbox {
     /// The placed shape at the given point in time.
     ///
-    /// The width and height of the shape must be greater than `padding` at all times.
+    /// The width and height of the shape must be greater than `padding` at all
+    /// times.
     pub value: PlacedShape,
 
-    /// Velocity information describing how the hitbox shape is changing over time.
+    /// Velocity information describing how the hitbox shape is changing over
+    /// time.
     pub vel: HbVel,
 }
 
@@ -117,19 +144,33 @@ impl Hitbox {
     }
 
     fn validate(&self, min_size: f64, present_time: f64) {
-        assert!(!self.vel.end_time.is_nan() && self.vel.end_time >= present_time, "end time must exceed present time");
+        assert!(
+            !self.vel.end_time.is_nan() && self.vel.end_time >= present_time,
+            "end time must exceed present time"
+        );
         if self.value.kind() == ShapeKind::Circle {
-            assert!((self.vel.resize.x - self.vel.resize.y).abs() < std::f64::EPSILON, "circle resize velocity must maintain aspect ratio");
+            assert!(
+                (self.vel.resize.x - self.vel.resize.y).abs() < std::f64::EPSILON,
+                "circle resize velocity must maintain aspect ratio"
+            );
         }
-        assert!(self.value.dims().x >= min_size && self.value.dims().y >= min_size, "shape width/height must be at least {}", min_size);
+        assert!(
+            self.value.dims().x >= min_size && self.value.dims().y >= min_size,
+            "shape width/height must be at least {}",
+            min_size
+        );
     }
 
     fn time_until_too_small(&self, min_size: f64) -> f64 {
         let min_size = min_size * 0.9;
         assert!(self.value.dims().x > min_size && self.value.dims().y > min_size);
         let mut time = f64::INFINITY;
-        if self.vel.resize.x < 0.0 { time = time.min((min_size - self.value.dims().x) / self.vel.value.x); }
-        if self.vel.resize.y < 0.0 { time = time.min((min_size - self.value.dims().y) / self.vel.value.y); }
+        if self.vel.resize.x < 0.0 {
+            time = time.min((min_size - self.value.dims().x) / self.vel.value.x);
+        }
+        if self.vel.resize.y < 0.0 {
+            time = time.min((min_size - self.value.dims().y) / self.vel.value.y);
+        }
         time
     }
 
@@ -146,13 +187,14 @@ impl Hitbox {
     }
 }
 
-/// A group id that may be used as a first measure to efficiently filter out hitboxes that don't interact.
+/// A group id that may be used as a first measure to efficiently filter out
+/// hitboxes that don't interact.
 ///
-/// The total number of groups used should in general be very small.
-/// Often 1 is enough, and 10 is excessive.
-/// As an example, in a [danmaku](https://en.wikipedia.org/wiki/Shoot_%27em_up#Bullet_hell_and_niche_appeal) game
-/// (which has many bullets on screen that do not interact with each other),
-/// we may use one group for bullets and one group for everything else,
+/// The total number of groups used should in general be very small. Often 1 is
+/// enough, and 10 is excessive. As an example, in a
+/// [danmaku](https://en.wikipedia.org/wiki/Shoot_%27em_up#Bullet_hell_and_niche_appeal)
+/// game (which has many bullets on screen that do not interact with each
+/// other), we may use one group for bullets and one group for everything else,
 /// to avoid the quadratic cost of comparing all nearby bullets with each other.
 pub type HbGroup = u32;
 
@@ -160,34 +202,37 @@ static DEFAULT_GROUPS: [HbGroup; 1] = [0];
 
 /// A trait that holds metadata for describing a hitbox.
 ///
-/// A user of `Collider` will need to implement an HbProfile that best suites their needs in a game.
-/// The most basic HbProfile will just contain an integer ID for the hitbox,
-/// but a user may define additional metadata for identfying the hitbox and describing interactivity.
-/// An HbProfile must implement the `Copy` trait and should not take up much memory.
+/// A user of `Collider` will need to implement an HbProfile that best suites
+/// their needs in a game. The most basic HbProfile will just contain an integer
+/// ID for the hitbox, but a user may define additional metadata for identfying
+/// the hitbox and describing interactivity. An HbProfile must implement the
+/// `Copy` trait and should not take up much memory.
 pub trait HbProfile: Copy {
     /// A unique identifier for the hitbox.
     ///
-    /// Trying to have multiple hitboxes with the same `id` to a `Collider` instance simultaneously
-    /// will result in a panic.
+    /// Trying to have multiple hitboxes with the same `id` to a `Collider`
+    /// instance simultaneously will result in a panic.
     fn id(&self) -> HbId;
 
-    /// Returns the group id associated with the hitbox.
-    /// Default is `Some(0)`.
+    /// Returns the group id associated with the hitbox. Default is `Some(0)`.
     ///
-    /// If `None` is returned, then no collisions will be reported
-    /// for this hitbox at all.
-    fn group(&self) -> Option<HbGroup> { Some(0) }
+    /// If `None` is returned, then no collisions will be reported for this
+    /// hitbox at all.
+    fn group(&self) -> Option<HbGroup> {
+        Some(0)
+    }
 
-    /// Returns a list of groups that this hitbox can interact with.
-    /// Default is `[0]`.
+    /// Returns a list of groups that this hitbox can interact with. Default is
+    /// `[0]`.
     ///
     /// Using large lists of groups may be inefficient.
-    fn interact_groups(&self) -> &'static [HbGroup] { &DEFAULT_GROUPS }
+    fn interact_groups(&self) -> &'static [HbGroup] {
+        &DEFAULT_GROUPS
+    }
 
     /// Returns true if the pair of hitboxes should be checked for collisions.
     ///
-    /// This method should be commutative.
-    /// This method should be consistent with `group` and `interact_groups`,
-    /// although possibly more restrictive.
+    /// This method should be commutative. This method should be consistent with
+    /// `group` and `interact_groups`, although possibly more restrictive.
     fn can_interact(&self, other: &Self) -> bool;
 }

--- a/src/float.rs
+++ b/src/float.rs
@@ -12,16 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::f64;
 use std::cmp::Ordering;
+use std::f64;
 
 // N64 wraps a non-NaN f64 value and implements Ord.
 
-pub fn n64(val: f64) -> N64 { N64::new(val) }
+pub fn n64(val: f64) -> N64 {
+    N64::new(val)
+}
 
 #[derive(PartialEq, PartialOrd, Copy, Clone, Default)]
 pub struct N64 {
-    val: f64
+    val: f64,
 }
 
 impl N64 {
@@ -31,7 +33,7 @@ impl N64 {
     }
 }
 
-impl Eq for N64 { }
+impl Eq for N64 {}
 
 impl Ord for N64 {
     fn cmp(&self, other: &Self) -> Ordering {

--- a/src/geom/card.rs
+++ b/src/geom/card.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::{Index, IndexMut};
 use std::fmt::{self, Debug, Formatter};
+use std::ops::{Index, IndexMut};
 
 /// Represents the four cardinal directions in 2D space.
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
@@ -38,7 +38,7 @@ impl Card {
             Card::MinusX => Card::PlusX,
             Card::PlusX => Card::MinusX,
             Card::MinusY => Card::PlusY,
-            Card::PlusY => Card::MinusY
+            Card::PlusY => Card::MinusY,
         }
     }
 
@@ -49,12 +49,14 @@ impl Card {
     }
 }
 
-/// A map from `Card` to `bool`, typically used to specify allowed normal vector directions.
+/// A map from `Card` to `bool`, typically used to specify allowed normal vector
+/// directions.
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
-pub struct CardMask { flags: [bool; 4] }
+pub struct CardMask {
+    flags: [bool; 4],
+}
 
 impl CardMask {
-
     /// Creates a `CardMask` with all values set to `false`.
     #[inline]
     pub fn empty() -> CardMask {
@@ -103,7 +105,13 @@ impl IndexMut<Card> for CardMask {
 
 impl Debug for CardMask {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "CardMask {{ MinusX: {}, MinusY: {}, PlusX: {}, PlusY: {} }}",
-               self[Card::MinusX], self[Card::MinusY], self[Card::PlusX], self[Card::PlusY])
+        write!(
+            f,
+            "CardMask {{ MinusX: {}, MinusY: {}, PlusX: {}, PlusY: {} }}",
+            self[Card::MinusX],
+            self[Card::MinusY],
+            self[Card::PlusX],
+            self[Card::PlusY]
+        )
     }
 }

--- a/src/geom/mod.rs
+++ b/src/geom/mod.rs
@@ -14,10 +14,10 @@
 
 //! Module containing geometry primitives.
 
+mod card;
 pub(crate) mod shape;
 mod vec;
-mod card;
 
-pub use self::shape::{ShapeKind, Shape, PlacedShape};
-pub use self::vec::*;
 pub use self::card::*;
+pub use self::shape::{PlacedShape, Shape, ShapeKind};
+pub use self::vec::*;

--- a/src/geom/shape/mod.rs
+++ b/src/geom/shape/mod.rs
@@ -54,10 +54,7 @@ impl Shape {
     // allows negative dims
     fn with_any_dims(kind: ShapeKind, dims: Vec2) -> Shape {
         if kind == ShapeKind::Circle {
-            assert!(
-                (dims.x - dims.y).abs() < std::f64::EPSILON,
-                "circle width must equal height"
-            );
+            assert_eq!(dims.x, dims.y, "circle width must equal height");
         }
         Shape { kind, dims }
     }

--- a/src/geom/shape/mod.rs
+++ b/src/geom/shape/mod.rs
@@ -14,12 +14,13 @@
 
 use std::cmp::Ordering;
 
-use geom::{Vec2, DirVec2, v2, Card, CardMask};
-use core::{Hitbox, HbVel};
+use core::{HbVel, Hitbox};
 use float::n64;
+use geom::{v2, Card, CardMask, DirVec2, Vec2};
 
 mod normals;
-#[cfg(test)] mod tests;
+#[cfg(test)]
+mod tests;
 
 /// Enumeration of kinds of shapes used by Collider.
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
@@ -27,7 +28,7 @@ pub enum ShapeKind {
     /// Circle.  Requires width and height to match.
     Circle,
     /// Axis-aligned rectangle.
-    Rect
+    Rect,
 }
 
 /// Represents a shape, without any position.
@@ -36,14 +37,15 @@ pub enum ShapeKind {
 #[derive(PartialEq, Copy, Clone, Debug)]
 pub struct Shape {
     kind: ShapeKind,
-    dims: Vec2
+    dims: Vec2,
 }
 
 impl Shape {
-    /// Constructs a new shape with the given `kind` and `dims` (width and height dimensions).
+    /// Constructs a new shape with the given `kind` and `dims` (width and
+    /// height dimensions).
     ///
-    /// Dimensions must be non-negative.
-    /// If `kind` is `Circle`, then the width and height must match.
+    /// Dimensions must be non-negative. If `kind` is `Circle`, then the width
+    /// and height must match.
     pub fn new(kind: ShapeKind, dims: Vec2) -> Shape {
         assert!(dims.x >= 0.0 && dims.y >= 0.0, "dims must be non-negative");
         Shape::with_any_dims(kind, dims)
@@ -52,7 +54,10 @@ impl Shape {
     // allows negative dims
     fn with_any_dims(kind: ShapeKind, dims: Vec2) -> Shape {
         if kind == ShapeKind::Circle {
-            assert!((dims.x - dims.y).abs() < std::f64::EPSILON, "circle width must equal height");
+            assert!(
+                (dims.x - dims.y).abs() < std::f64::EPSILON,
+                "circle width must equal height"
+            );
         }
         Shape { kind, dims }
     }
@@ -63,7 +68,8 @@ impl Shape {
         Shape::new(ShapeKind::Circle, v2(diam, diam))
     }
 
-    /// Constructs a new axis-aligned rectangle shape with the given `dims` (width and height dimensions).
+    /// Constructs a new axis-aligned rectangle shape with the given `dims`
+    /// (width and height dimensions).
     #[inline]
     pub fn rect(dims: Vec2) -> Shape {
         Shape::new(ShapeKind::Rect, dims)
@@ -104,7 +110,7 @@ pub struct PlacedShape {
     /// The position of the center of the shape.
     pub pos: Vec2,
     /// The shape.
-    pub shape: Shape
+    pub shape: Shape,
 }
 
 impl PlacedShape {
@@ -127,32 +133,42 @@ impl PlacedShape {
     }
 
     /// Returns the lowest x coordinate of the `PlacedShape`.
-    pub fn min_x(&self) -> f64 { self.bounds_left() }
+    pub fn min_x(&self) -> f64 {
+        self.bounds_left()
+    }
 
     /// Returns the lowest y coordinate of the `PlacedShape`.
-    pub fn min_y(&self) -> f64 { self.bounds_bottom() }
+    pub fn min_y(&self) -> f64 {
+        self.bounds_bottom()
+    }
 
     /// Returns the highest x coordinate of the `PlacedShape`.
-    pub fn max_x(&self) -> f64 { self.bounds_right() }
+    pub fn max_x(&self) -> f64 {
+        self.bounds_right()
+    }
 
     /// Returns the highest y coordinate of the `PlacedShape`.
-    pub fn max_y(&self) -> f64 { self.bounds_top() }
+    pub fn max_y(&self) -> f64 {
+        self.bounds_top()
+    }
 
-    /// Returns `true` if the two shapes overlap, subject to negligible numerical error.
+    /// Returns `true` if the two shapes overlap, subject to negligible
+    /// numerical error.
     pub fn overlaps(&self, other: &PlacedShape) -> bool {
         self.normal_from(other).len() >= 0.0
     }
 
-    /// Returns a normal vector that points in the direction from `other` to `self`.
+    /// Returns a normal vector that points in the direction from `other` to
+    /// `self`.
     ///
-    /// The length of this vector is the minimum distance that `self` would need to
-    /// be moved along this direction so that it is no longer overlapping `other`.
-    /// If the shapes are not overlappingt to begin with, then the length of this vector
-    /// is negative, and describes the minimum distance that `self` would need to
-    /// be moved so that it is just overlapping `other`.
+    /// The length of this vector is the minimum distance that `self` would need
+    /// to be moved along this direction so that it is no longer overlapping
+    /// `other`. If the shapes are not overlappingt to begin with, then the
+    /// length of this vector is negative, and describes the minimum distance
+    /// that `self` would need to be moved so that it is just overlapping
+    /// `other`.
     ///
-    /// (As a minor caveat,
-    /// when computing the normal between two `Rect` shapes,
+    /// (As a minor caveat, when computing the normal between two `Rect` shapes,
     /// the direction will always be axis-aligned.)
     pub fn normal_from(&self, other: &PlacedShape) -> DirVec2 {
         match (self.kind(), other.kind()) {
@@ -163,24 +179,34 @@ impl PlacedShape {
         }
     }
 
-    /// Returns a normal vector like `normal_from`, but only certain normal directions are permitted.
+    /// Returns a normal vector like `normal_from`, but only certain normal
+    /// directions are permitted.
     ///
-    /// A normal vector with a cardinal component that is not present in the `mask`
-    /// will not be returned, and the next-in-line normal vector will be used instead.
-    /// This function panics if `mask` is empty, or if both shapes are circles and
-    /// `mask` is anything but full.
+    /// A normal vector with a cardinal component that is not present in the
+    /// `mask` will not be returned, and the next-in-line normal vector will be
+    /// used instead. This function panics if `mask` is empty, or if both shapes
+    /// are circles and `mask` is anything but full.
     pub fn masked_normal_from(&self, other: &PlacedShape, mask: CardMask) -> DirVec2 {
         match (self.kind(), other.kind()) {
-            (ShapeKind::Rect, ShapeKind::Rect) => normals::masked_rect_rect_normal(self, other, mask),
-            (ShapeKind::Rect, ShapeKind::Circle) => normals::masked_rect_circle_normal(self, other, mask),
-            (ShapeKind::Circle, ShapeKind::Rect) => normals::masked_rect_circle_normal(other, self, mask.flip()).flip(),
-            (ShapeKind::Circle, ShapeKind::Circle) => normals::masked_circle_circle_normal(self, other, mask),
+            (ShapeKind::Rect, ShapeKind::Rect) => {
+                normals::masked_rect_rect_normal(self, other, mask)
+            }
+            (ShapeKind::Rect, ShapeKind::Circle) => {
+                normals::masked_rect_circle_normal(self, other, mask)
+            }
+            (ShapeKind::Circle, ShapeKind::Rect) => {
+                normals::masked_rect_circle_normal(other, self, mask.flip()).flip()
+            }
+            (ShapeKind::Circle, ShapeKind::Circle) => {
+                normals::masked_circle_circle_normal(self, other, mask)
+            }
         }
     }
 
     /// Returns the point of contact between two shapes.
     ///
-    /// If the shapes are not overlapping, returns the nearest point between the shapes.
+    /// If the shapes are not overlapping, returns the nearest point between the
+    /// shapes.
     pub fn contact_point(&self, other: &PlacedShape) -> Vec2 {
         match (self.kind(), other.kind()) {
             (ShapeKind::Rect, ShapeKind::Rect) => normals::rect_rect_contact(self, other),
@@ -235,7 +261,10 @@ impl PlacedShape {
     }
 
     pub(crate) fn advance(&self, vel: Vec2, resize_vel: Vec2, elapsed: f64) -> PlacedShape {
-        PlacedShape::new(self.pos + vel * elapsed, self.shape.advance(resize_vel, elapsed))
+        PlacedShape::new(
+            self.pos + vel * elapsed,
+            self.shape.advance(resize_vel, elapsed),
+        )
     }
 }
 
@@ -243,10 +272,18 @@ pub(crate) trait PlacedBounds {
     fn bounds_center(&self) -> &Vec2;
     fn bounds_dims(&self) -> &Vec2;
 
-    fn bounds_bottom(&self) -> f64 { self.bounds_center().y - self.bounds_dims().y * 0.5 }
-    fn bounds_left(&self) -> f64 { self.bounds_center().x - self.bounds_dims().x * 0.5 }
-    fn bounds_top(&self) -> f64 { self.bounds_center().y + self.bounds_dims().y * 0.5 }
-    fn bounds_right(&self) -> f64 { self.bounds_center().x + self.bounds_dims().x * 0.5 }
+    fn bounds_bottom(&self) -> f64 {
+        self.bounds_center().y - self.bounds_dims().y * 0.5
+    }
+    fn bounds_left(&self) -> f64 {
+        self.bounds_center().x - self.bounds_dims().x * 0.5
+    }
+    fn bounds_top(&self) -> f64 {
+        self.bounds_center().y + self.bounds_dims().y * 0.5
+    }
+    fn bounds_right(&self) -> f64 {
+        self.bounds_center().x + self.bounds_dims().x * 0.5
+    }
 
     fn edge(&self, card: Card) -> f64 {
         match card {
@@ -258,10 +295,11 @@ pub(crate) trait PlacedBounds {
     }
 
     fn max_edge(&self) -> f64 {
-        Card::values().iter()
-                      .map(|&card| self.edge(card).abs())
-                      .max_by_key(|&edge| n64(edge))
-                      .unwrap()
+        Card::values()
+            .iter()
+            .map(|&card| self.edge(card).abs())
+            .max_by_key(|&edge| n64(edge))
+            .unwrap()
     }
 
     fn card_overlap(&self, src: &Self, card: Card) -> f64 {
@@ -272,20 +310,24 @@ pub(crate) trait PlacedBounds {
         let x = match sector.x {
             Ordering::Less => self.bounds_left(),
             Ordering::Greater => self.bounds_right(),
-            Ordering::Equal => panic!("expected corner sector")
+            Ordering::Equal => panic!("expected corner sector"),
         };
         let y = match sector.y {
             Ordering::Less => self.bounds_bottom(),
             Ordering::Greater => self.bounds_top(),
-            Ordering::Equal => panic!("expected corner sector")
+            Ordering::Equal => panic!("expected corner sector"),
         };
         v2(x, y)
     }
 }
 
 impl PlacedBounds for PlacedShape {
-    fn bounds_center(&self) -> &Vec2 { &self.pos }
-    fn bounds_dims(&self) -> &Vec2 { &self.shape.dims }
+    fn bounds_center(&self) -> &Vec2 {
+        &self.pos
+    }
+    fn bounds_dims(&self) -> &Vec2 {
+        &self.shape.dims
+    }
 }
 
 fn interval_sector(left: f64, right: f64, val: f64) -> Ordering {
@@ -301,7 +343,7 @@ fn interval_sector(left: f64, right: f64, val: f64) -> Ordering {
 #[derive(PartialEq, Eq, Copy, Clone)]
 pub(crate) struct Sector {
     x: Ordering,
-    y: Ordering
+    y: Ordering,
 }
 
 impl Sector {
@@ -316,8 +358,16 @@ impl Sector {
     pub fn corner_cards(self) -> Option<(Card, Card)> {
         if self.is_corner() {
             Some((
-                if self.x == Ordering::Greater { Card::PlusX } else { Card::MinusX },
-                if self.y == Ordering::Greater { Card::PlusY } else { Card::MinusY },
+                if self.x == Ordering::Greater {
+                    Card::PlusX
+                } else {
+                    Card::MinusX
+                },
+                if self.y == Ordering::Greater {
+                    Card::PlusY
+                } else {
+                    Card::MinusY
+                },
             ))
         } else {
             None

--- a/src/geom/shape/normals.rs
+++ b/src/geom/shape/normals.rs
@@ -12,15 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use geom::*;
-use geom::shape::{PlacedBounds, Sector};
 use float::n64;
+use geom::shape::{PlacedBounds, Sector};
+use geom::*;
 
 // This module contains methods to solve for the normal vector
 // between two PlacedShapes.
 
 pub fn rect_rect_normal(dst: &PlacedShape, src: &PlacedShape) -> DirVec2 {
-    let (card, overlap) = Card::values().iter().cloned()
+    let (card, overlap) = Card::values()
+        .iter()
+        .cloned()
         .map(|card| (card, dst.card_overlap(src, card)))
         .min_by_key(|&(_, overlap)| n64(overlap))
         .unwrap();
@@ -30,21 +32,28 @@ pub fn rect_rect_normal(dst: &PlacedShape, src: &PlacedShape) -> DirVec2 {
 pub fn circle_circle_normal(dst: &PlacedShape, src: &PlacedShape) -> DirVec2 {
     let mut dir = dst.pos - src.pos;
     let dist = dir.len();
-    if dist == 0.0 { dir = v2(1.0, 0.0); }
+    if dist == 0.0 {
+        dir = v2(1.0, 0.0);
+    }
     DirVec2::new(dir, (src.dims().x + dst.dims().x) * 0.5 - dist)
 }
 
 pub fn rect_circle_normal(dst: &PlacedShape, src: &PlacedShape) -> DirVec2 {
     let sector = dst.sector(src.pos);
     if sector.is_corner() {
-        circle_circle_normal(&PlacedShape::new(dst.corner(sector), Shape::circle(0.0)), src)
+        circle_circle_normal(
+            &PlacedShape::new(dst.corner(sector), Shape::circle(0.0)),
+            src,
+        )
     } else {
         rect_rect_normal(dst, src)
     }
 }
 
 pub fn masked_rect_rect_normal(dst: &PlacedShape, src: &PlacedShape, mask: CardMask) -> DirVec2 {
-    let (card, overlap) = Card::values().iter().cloned()
+    let (card, overlap) = Card::values()
+        .iter()
+        .cloned()
         .filter(|&card| mask[card])
         .map(|card| (card, dst.card_overlap(src, card)))
         .min_by_key(|&(_, overlap)| n64(overlap))
@@ -52,15 +61,25 @@ pub fn masked_rect_rect_normal(dst: &PlacedShape, src: &PlacedShape, mask: CardM
     DirVec2::new(card.into(), overlap)
 }
 
-pub fn masked_circle_circle_normal(dst: &PlacedShape, src: &PlacedShape, mask: CardMask) -> DirVec2 {
-    assert!(mask == CardMask::full(), "CardMask for circle-circle normal must be full");
+pub fn masked_circle_circle_normal(
+    dst: &PlacedShape,
+    src: &PlacedShape,
+    mask: CardMask,
+) -> DirVec2 {
+    assert!(
+        mask == CardMask::full(),
+        "CardMask for circle-circle normal must be full"
+    );
     circle_circle_normal(dst, src)
 }
 
 pub fn masked_rect_circle_normal(dst: &PlacedShape, src: &PlacedShape, mask: CardMask) -> DirVec2 {
     let sector = dst.sector(src.pos);
     if mask_has_corner_sector(sector, mask.flip()) {
-        circle_circle_normal(&PlacedShape::new(dst.corner(sector), Shape::circle(0.0)), src)
+        circle_circle_normal(
+            &PlacedShape::new(dst.corner(sector), Shape::circle(0.0)),
+            src,
+        )
     } else {
         masked_rect_rect_normal(dst, src, mask)
     }

--- a/src/geom/shape/tests.rs
+++ b/src/geom/shape/tests.rs
@@ -17,13 +17,19 @@ use geom::*;
 #[test]
 fn test_circle_advance() {
     let shape_1 = Shape::circle(2.0).place(v2(3.0, 5.0));
-    assert_eq!(shape_1.advance(v2(1.0, 2.0), v2(-0.25, -0.25), 2.0), Shape::circle(1.5).place(v2(5.0, 9.0)));
+    assert_eq!(
+        shape_1.advance(v2(1.0, 2.0), v2(-0.25, -0.25), 2.0),
+        Shape::circle(1.5).place(v2(5.0, 9.0))
+    );
 }
 
 #[test]
 fn test_rect_advance() {
     let shape_1 = Shape::rect(v2(2.0, 5.0)).place(v2(3.0, 5.0));
-    assert_eq!(shape_1.advance(v2(1.0, 2.0), v2(-0.25, 1.0), 2.0), Shape::rect(v2(1.5, 7.0)).place(v2(5.0, 9.0)));
+    assert_eq!(
+        shape_1.advance(v2(1.0, 2.0), v2(-0.25, 1.0), 2.0),
+        Shape::rect(v2(1.5, 7.0)).place(v2(5.0, 9.0))
+    );
 }
 
 #[test]
@@ -59,7 +65,10 @@ fn test_rect_rect_normal() {
 fn test_circle_circle_normal() {
     let src = Shape::circle(2.0).place(v2(1.0, 1.0));
     let dst = Shape::circle(3.0).place(v2(2.0, 0.0));
-    assert_eq!(dst.normal_from(&src), DirVec2::new(v2(1.0, -1.0), 2.5 - (2.0f64).sqrt()));
+    assert_eq!(
+        dst.normal_from(&src),
+        DirVec2::new(v2(1.0, -1.0), 2.5 - (2.0f64).sqrt())
+    );
 }
 
 #[test]
@@ -76,13 +85,25 @@ fn test_rect_circle_normal() {
     assert_eq!(dst.normal_from(&src), DirVec2::new(v2(0.0, 1.0), 0.25));
 
     let dst = Shape::circle(2.5).place(v2(-2.0, -2.0));
-    assert_eq!(dst.normal_from(&src), DirVec2::new(v2(-1.0, -1.0), 1.25 - (2.0f64).sqrt()));
+    assert_eq!(
+        dst.normal_from(&src),
+        DirVec2::new(v2(-1.0, -1.0), 1.25 - (2.0f64).sqrt())
+    );
     let dst = Shape::circle(2.5).place(v2(2.0, -2.0));
-    assert_eq!(dst.normal_from(&src), DirVec2::new(v2(1.0, -1.0), 1.25 - (2.0f64).sqrt()));
+    assert_eq!(
+        dst.normal_from(&src),
+        DirVec2::new(v2(1.0, -1.0), 1.25 - (2.0f64).sqrt())
+    );
     let dst = Shape::circle(2.5).place(v2(-2.0, 2.0));
-    assert_eq!(dst.normal_from(&src), DirVec2::new(v2(-1.0, 1.0), 1.25 - (2.0f64).sqrt()));
+    assert_eq!(
+        dst.normal_from(&src),
+        DirVec2::new(v2(-1.0, 1.0), 1.25 - (2.0f64).sqrt())
+    );
     let dst = Shape::circle(2.5).place(v2(2.0, 2.0));
-    assert_eq!(dst.normal_from(&src), DirVec2::new(v2(1.0, 1.0), 1.25 - (2.0f64).sqrt()));
+    assert_eq!(
+        dst.normal_from(&src),
+        DirVec2::new(v2(1.0, 1.0), 1.25 - (2.0f64).sqrt())
+    );
 }
 
 #[test]
@@ -90,9 +111,15 @@ fn test_masked_rect_rect_normal() {
     let src = Shape::rect(v2(4.0, 4.0)).place(v2(1.0, 1.0));
     let dst = Shape::rect(v2(8.0, 8.0)).place(v2(6.0, -5.0));
     let mut mask = CardMask::full();
-    assert_eq!(dst.masked_normal_from(&src, mask), DirVec2::new(v2(0.0, -1.0), 0.0));
+    assert_eq!(
+        dst.masked_normal_from(&src, mask),
+        DirVec2::new(v2(0.0, -1.0), 0.0)
+    );
     mask[Card::MinusY] = false;
-    assert_eq!(dst.masked_normal_from(&src, mask), DirVec2::new(v2(1.0, 0.0), 1.0));
+    assert_eq!(
+        dst.masked_normal_from(&src, mask),
+        DirVec2::new(v2(1.0, 0.0), 1.0)
+    );
 }
 
 #[test]
@@ -100,12 +127,24 @@ fn test_masked_rect_circle_normal() {
     let src = Shape::rect(v2(2.0, 2.0)).place(v2(0.0, 0.0));
     let dst = Shape::circle(2.5).place(v2(-2.0, 2.0));
     let mut mask = CardMask::full();
-    assert_eq!(dst.masked_normal_from(&src, mask), DirVec2::new(v2(-1.0, 1.0), 1.25 - (2.0f64).sqrt()));
+    assert_eq!(
+        dst.masked_normal_from(&src, mask),
+        DirVec2::new(v2(-1.0, 1.0), 1.25 - (2.0f64).sqrt())
+    );
     mask[Card::PlusX] = false;
-    assert_eq!(src.masked_normal_from(&dst, mask.flip()), DirVec2::new(v2(1.0, -1.0), 1.25 - (2.0f64).sqrt()));
-    assert_eq!(dst.masked_normal_from(&src, mask), DirVec2::new(v2(-1.0, 1.0), 1.25 - (2.0f64).sqrt()));
+    assert_eq!(
+        src.masked_normal_from(&dst, mask.flip()),
+        DirVec2::new(v2(1.0, -1.0), 1.25 - (2.0f64).sqrt())
+    );
+    assert_eq!(
+        dst.masked_normal_from(&src, mask),
+        DirVec2::new(v2(-1.0, 1.0), 1.25 - (2.0f64).sqrt())
+    );
     mask[Card::PlusY] = false;
-    assert_eq!(dst.masked_normal_from(&src, mask), DirVec2::new(v2(-1.0, 0.0), 0.25));
+    assert_eq!(
+        dst.masked_normal_from(&src, mask),
+        DirVec2::new(v2(-1.0, 0.0), 0.25)
+    );
 }
 
 #[test]

--- a/src/geom/vec.rs
+++ b/src/geom/vec.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::{Add, Sub, Mul, Neg, AddAssign, SubAssign, MulAssign};
 use geom::card::Card;
+use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 /// A 2-D Cartesian vector using finite `f64` values.
 #[derive(PartialEq, Copy, Clone, Debug, Default)]
@@ -21,7 +21,7 @@ pub struct Vec2 {
     /// The x-coordinate.
     pub x: f64,
     /// The y-coordinate.
-    pub y: f64
+    pub y: f64,
 }
 
 impl Vec2 {
@@ -39,20 +39,22 @@ impl Vec2 {
 
     /// Computes the square of the Euclidean length of the vector.
     ///
-    /// Due to underflow, this might be `0.0` even if `x` and `y` are non-zero but very small.
+    /// Due to underflow, this might be `0.0` even if `x` and `y` are non-zero
+    /// but very small.
     pub fn len_sq(&self) -> f64 {
         self.x * self.x + self.y * self.y
     }
 
     /// Computes the the Euclidean length of the vector.
     ///
-    /// Due to underflow, this might be `0.0` even if `x` and `y` are non-zero but very small.
+    /// Due to underflow, this might be `0.0` even if `x` and `y` are non-zero
+    /// but very small.
     pub fn len(&self) -> f64 {
         self.len_sq().sqrt()
     }
 
-    /// Returns a vector in the same direction as `self` but with length (approximately) `1.0`,
-    /// or `None` if `self.len() == 0.0`.
+    /// Returns a vector in the same direction as `self` but with length
+    /// (approximately) `1.0`, or `None` if `self.len() == 0.0`.
     pub fn normalize(&self) -> Option<Vec2> {
         let len = self.len();
         if len == 0.0 {
@@ -75,13 +77,15 @@ impl Vec2 {
 
     /// Linearly interpolates between `self` and `other`.
     ///
-    /// Using `ratio = 0.0` will return `self`, and using `ratio = 1.0` will return `other`.
-    /// Can also extrapolate using `ratio > 1.0` or `ratio < 0.0`.
+    /// Using `ratio = 0.0` will return `self`, and using `ratio = 1.0` will
+    /// return `other`. Can also extrapolate using `ratio > 1.0` or
+    /// `ratio < 0.0`.
     pub fn lerp(&self, other: Vec2, ratio: f64) -> Vec2 {
         (1.0 - ratio) * *self + ratio * other
     }
 
-    /// Rotates the vector by `angle` radians counter-clockwise (assuming +x is right and +y is up).
+    /// Rotates the vector by `angle` radians counter-clockwise (assuming +x is
+    /// right and +y is up).
     pub fn rotate(&self, angle: f64) -> Vec2 {
         let sin = angle.sin();
         let cos = angle.cos();
@@ -113,7 +117,7 @@ impl MulAssign<f64> for Vec2 {
 impl Mul<Vec2> for Vec2 {
     type Output = f64;
     fn mul(self, rhs: Vec2) -> f64 {
-        self.x*rhs.x + self.y*rhs.y
+        self.x * rhs.x + self.y * rhs.y
     }
 }
 
@@ -171,16 +175,15 @@ pub fn v2(x: f64, y: f64) -> Vec2 {
 
 /// A 2-D vector that separates direction from length.
 ///
-/// This may be used rather than `Vec2` if the length
-/// may be at or near `0.0` but the direction is still important,
-/// or to distinguish between a vector with a negative length
-/// and a vector in the opposite direction of positive length.
-/// Such distinctions are necessary when describing the
-/// normal distance between `PlacedShape`s.
+/// This may be used rather than `Vec2` if the length may be at or near `0.0`
+/// but the direction is still important, or to distinguish between a vector
+/// with a negative length and a vector in the opposite direction of positive
+/// length. Such distinctions are necessary when describing the normal distance
+/// between `PlacedShape`s.
 #[derive(PartialEq, Copy, Clone, Debug)]
 pub struct DirVec2 {
     dir: Vec2,
-    len: f64
+    len: f64,
 }
 
 impl DirVec2 {
@@ -188,7 +191,10 @@ impl DirVec2 {
     ///
     /// `dir` is normalized before being set.
     pub fn new(dir: Vec2, len: f64) -> DirVec2 {
-        DirVec2 { dir: dir.normalize().unwrap(), len }
+        DirVec2 {
+            dir: dir.normalize().unwrap(),
+            len,
+        }
     }
 
     /// Returns the direction as a unit vector.
@@ -205,12 +211,18 @@ impl DirVec2 {
 
     /// Returns a new vector with the same `len` but reversed `dir`.
     pub fn flip(&self) -> DirVec2 {
-        DirVec2 { dir: -self.dir, len: self.len }
+        DirVec2 {
+            dir: -self.dir,
+            len: self.len,
+        }
     }
 }
 
 impl From<DirVec2> for Vec2 {
     fn from(dir_vec: DirVec2) -> Vec2 {
-        Vec2::new(dir_vec.dir().x * dir_vec.len(), dir_vec.dir().y * dir_vec.len())
+        Vec2::new(
+            dir_vec.dir().x * dir_vec.len(),
+            dir_vec.dir().y * dir_vec.len(),
+        )
     }
 }

--- a/src/index_rect.rs
+++ b/src/index_rect.rs
@@ -23,7 +23,10 @@ pub struct IndexRect {
 impl IndexRect {
     // start is inclusive, end is exclusive
     pub fn new(start: (i32, i32), end: (i32, i32)) -> IndexRect {
-        assert!(start.0 < end.0 && start.1 < end.1, "IndexRect contains no elements");
+        assert!(
+            start.0 < end.0 && start.1 < end.1,
+            "IndexRect contains no elements"
+        );
         IndexRect { start, end }
     }
 
@@ -38,12 +41,12 @@ impl IndexRect {
 
 pub struct Iter {
     rect: IndexRect,
-    val: Option<(i32, i32)>
+    val: Option<(i32, i32)>,
 }
 
 impl Iter {
     fn new(rect: IndexRect) -> Iter {
-        Iter { rect, val : None }
+        Iter { rect, val: None }
     }
 }
 
@@ -61,10 +64,8 @@ impl Iterator for Iter {
                 } else {
                     Some((x, y + 1))
                 }
-            },
-            None => {
-                Some(self.rect.start)
             }
+            None => Some(self.rect.start),
         };
         self.val
     }
@@ -77,7 +78,7 @@ mod tests {
 
     #[test]
     fn test_iterator() {
-        let rect = IndexRect::new((2,3), (5, 7));
+        let rect = IndexRect::new((2, 3), (5, 7));
         let mut set = HashSet::new();
         for (x, y) in rect.iter() {
             assert!(x >= 2 && x < 5);
@@ -89,13 +90,13 @@ mod tests {
 
     #[test]
     fn test_contains() {
-        let rect = IndexRect::new((2,3),(5,7));
-        assert!(rect.contains((2,3)));
-        assert!(rect.contains((4,6)));
-        assert!(!rect.contains((1,3)));
-        assert!(!rect.contains((2,2)));
-        assert!(!rect.contains((5,6)));
-        assert!(!rect.contains((4,7)));
+        let rect = IndexRect::new((2, 3), (5, 7));
+        assert!(rect.contains((2, 3)));
+        assert!(rect.contains((4, 6)));
+        assert!(!rect.contains((1, 3)));
+        assert!(!rect.contains((2, 2)));
+        assert!(!rect.contains((5, 6)));
+        assert!(!rect.contains((4, 7)));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,34 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Collider is a library for continuous 2D collision detection,
-//! for use with game developement.
+//! Collider is a library for continuous 2D collision detection, for use with
+//! game developement.
 //!
-//! Most game engines follow the approach of periodically updating the
-//! positions of all shapes and checking for collisions at a frozen snapshot in time.
+//! Most game engines follow the approach of periodically updating the positions
+//! of all shapes and checking for collisions at a frozen snapshot in time.
 //! [Continuous collision detection](https://en.wikipedia.org/wiki/Collision_detection#A_posteriori_.28discrete.29_versus_a_priori_.28continuous.29),
-//! on the other hand, means that the time of collision is determined very precisely,
-//! and the user is not restricted to a fixed time-stepping method.
-//! There are currently two kinds of shapes supported by Collider: circles and rectangles.
-//! The user specifies the positions and velocities of these shapes, which
-//! they can update at any time, and Collider will solve for the precise times of
-//! collision and separation.
+//! on the other hand, means that the time of collision is determined very
+//! precisely, and the user is not restricted to a fixed time-stepping method.
+//! There are currently two kinds of shapes supported by Collider: circles and
+//! rectangles. The user specifies the positions and velocities of these shapes,
+//! which they can update at any time, and Collider will solve for the precise
+//! times of collision and separation.
 //!
-//! There are certain advantages that continuous collision detection
-//! holds over the traditional approach.
-//! In a game engine, the position of a sprite may be updated to overlap a wall,
-//! and in a traditional collision system there would need to be a post-correction
-//! to make sure the sprite does not appear inside of the wall.
-//! This is not needed with continuous collision detection, since
+//! There are certain advantages that continuous collision detection holds over
+//! the traditional approach. In a game engine, the position of a sprite may be
+//! updated to overlap a wall, and in a traditional collision system there would
+//! need to be a post-correction to make sure the sprite does not appear inside
+//! of the wall. This is not needed with continuous collision detection, since
 //! the precise time and location at which the sprite touches the wall is known.
-//! Traditional collision detection may have an issue with "tunneling," in which a
-//! fast small object runs into a narrow wall and collision detection misses it,
-//! or two fast small objects fly right through each other and collision detection misses it.
-//! This is also not a problem for continuous collision detection.
-//! It is also debatable that continuous collision detection may be
-//! more efficient in certain circumstances,
-//! since the hitboxes may be updated less frequently and still maintain a
-//! smooth appearance over time.
+//! Traditional collision detection may have an issue with "tunneling," in which
+//! a fast small object runs into a narrow wall and collision detection misses
+//! it, or two fast small objects fly right through each other and collision
+//! detection misses it. This is also not a problem for continuous collision
+//! detection. It is also debatable that continuous collision detection may be
+//! more efficient in certain circumstances, since the hitboxes may be updated
+//! less frequently and still maintain a smooth appearance over time.
 //!
 //! #Example
 //! ```
@@ -89,11 +87,12 @@
 
 extern crate fnv;
 
+mod core;
 mod float;
 pub mod geom;
-mod util;
-mod core;
 mod index_rect;
-#[cfg(test)] mod tests;
+#[cfg(test)]
+mod tests;
+mod util;
 
 pub use core::*;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::f64;
 use super::{Collider, HbEvent, HbId, HbProfile, HbVel};
-use geom::{Shape, v2};
+use geom::{v2, Shape};
+use std::f64;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
-struct TestHbProfile { id: HbId }
+struct TestHbProfile {
+    id: HbId,
+}
 
 impl From<HbId> for TestHbProfile {
     fn from(id: HbId) -> TestHbProfile {
@@ -26,8 +28,12 @@ impl From<HbId> for TestHbProfile {
 }
 
 impl HbProfile for TestHbProfile {
-    fn id(&self) -> HbId { self.id }
-    fn can_interact(&self, _other: &TestHbProfile) -> bool { true }
+    fn id(&self) -> HbId {
+        self.id
+    }
+    fn can_interact(&self, _other: &TestHbProfile) -> bool {
+        true
+    }
 }
 
 fn advance_to_event(collider: &mut Collider<TestHbProfile>, time: f64) {
@@ -73,9 +79,15 @@ fn smoke_test() {
     assert_eq!(overlaps, vec![]);
 
     advance_to_event(&mut collider, 9.0);
-    assert_eq!(collider.next(), Some((HbEvent::Collide, 0.into(), 1.into())));
+    assert_eq!(
+        collider.next(),
+        Some((HbEvent::Collide, 0.into(), 1.into()))
+    );
     advance_to_event(&mut collider, 11.125);
-    assert_eq!(collider.next(), Some((HbEvent::Separate, 0.into(), 1.into())));
+    assert_eq!(
+        collider.next(),
+        Some((HbEvent::Separate, 0.into(), 1.into()))
+    );
     advance(&mut collider, 23.0);
 }
 
@@ -123,7 +135,10 @@ fn test_hitbox_updates() {
 
     advance_to_event(&mut collider, 19.0);
 
-    assert_eq!(collider.next(), Some((HbEvent::Collide, 0.into(), 1.into())));
+    assert_eq!(
+        collider.next(),
+        Some((HbEvent::Collide, 0.into(), 1.into()))
+    );
     let mut hitbox = collider.get_hitbox(0);
     assert_eq!(hitbox.value, Shape::square(2.0).place(v2(0.0, -6.0)));
     assert_eq!(hitbox.vel.value, v2(0.0, -1.0));
@@ -141,11 +156,17 @@ fn test_hitbox_updates() {
     collider.set_hitbox_vel(1, hitbox.vel);
 
     let hitbox = Shape::rect(v2(2.0, 20.0)).place(v2(0.0, 0.0)).still();
-    assert_eq!(sort(collider.add_hitbox(2.into(), hitbox)), vec![0.into(), 1.into()]);
+    assert_eq!(
+        sort(collider.add_hitbox(2.into(), hitbox)),
+        vec![0.into(), 1.into()]
+    );
 
     advance_to_event(&mut collider, 21.125);
 
-    assert_eq!(collider.next(), Some((HbEvent::Separate, 0.into(), 1.into())));
+    assert_eq!(
+        collider.next(),
+        Some((HbEvent::Separate, 0.into(), 1.into()))
+    );
 
     advance(&mut collider, 26.125);
 
@@ -159,8 +180,18 @@ fn test_hitbox_updates() {
 fn test_get_overlaps() {
     let mut collider = Collider::<TestHbProfile>::new(4.0, 0.25);
 
-    collider.add_hitbox(0.into(), Shape::square(2.0).place(v2(-10.0, 0.0)).moving(v2(1.0, 0.0)));
-    collider.add_hitbox(1.into(), Shape::circle(2.0).place(v2(10.0, 0.0)).moving(v2(-1.0, 0.0)));
+    collider.add_hitbox(
+        0.into(),
+        Shape::square(2.0)
+            .place(v2(-10.0, 0.0))
+            .moving(v2(1.0, 0.0)),
+    );
+    collider.add_hitbox(
+        1.into(),
+        Shape::circle(2.0)
+            .place(v2(10.0, 0.0))
+            .moving(v2(-1.0, 0.0)),
+    );
     collider.add_hitbox(2.into(), Shape::square(2.0).place(v2(0.0, 0.0)).still());
 
     assert_eq!(collider.get_overlaps(0), vec![]);
@@ -204,28 +235,48 @@ fn test_get_overlaps() {
 fn test_query_overlaps() {
     let mut collider = Collider::<TestHbProfile>::new(4.0, 0.25);
 
-    collider.add_hitbox(0.into(), Shape::square(2.0).place(v2(-5.0, 0.0)).moving(v2(1.0, 0.0)));
+    collider.add_hitbox(
+        0.into(),
+        Shape::square(2.0).place(v2(-5.0, 0.0)).moving(v2(1.0, 0.0)),
+    );
     collider.add_hitbox(1.into(), Shape::circle(2.0).place(v2(0.0, 0.0)).still());
-    collider.add_hitbox(2.into(), Shape::circle(2.0).place(v2(10.0, 0.0)).moving(v2(-1.0, 0.0)));
+    collider.add_hitbox(
+        2.into(),
+        Shape::circle(2.0)
+            .place(v2(10.0, 0.0))
+            .moving(v2(-1.0, 0.0)),
+    );
 
     let test_shape = Shape::circle(2.0).place(v2(-1.0, 0.5));
-    assert_eq!(collider.query_overlaps(&test_shape, &5.into()), vec![1.into()]);
+    assert_eq!(
+        collider.query_overlaps(&test_shape, &5.into()),
+        vec![1.into()]
+    );
 
     advance(&mut collider, 3.0);
-    assert_eq!(sort(collider.query_overlaps(&test_shape, &5.into())), vec![0.into(), 1.into()]);
+    assert_eq!(
+        sort(collider.query_overlaps(&test_shape, &5.into())),
+        vec![0.into(), 1.into()]
+    );
 }
 
 #[test]
 fn test_separate_initial_overlap() {
     let mut collider = Collider::<TestHbProfile>::new(4.0, 0.25);
 
-    let overlaps = collider.add_hitbox(0.into(), Shape::square(1.).place(v2(0., 0.)).moving(v2(0.0, 1.)));
+    let overlaps = collider.add_hitbox(
+        0.into(),
+        Shape::square(1.).place(v2(0., 0.)).moving(v2(0.0, 1.)),
+    );
     assert_eq!(overlaps, vec![]);
     let overlaps = collider.add_hitbox(1.into(), Shape::square(1.).place(v2(0., 0.)).still());
     assert_eq!(overlaps, vec![0.into()]);
 
     advance_to_event(&mut collider, 1.25);
-    assert_eq!(collider.next(), Some((HbEvent::Separate, 0.into(), 1.into())));
+    assert_eq!(
+        collider.next(),
+        Some((HbEvent::Separate, 0.into(), 1.into()))
+    );
 
     advance(&mut collider, 1.5);
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{hash_set, HashSet};
 use fnv::FnvHashSet;
 use std::borrow::Borrow;
+use std::collections::{hash_set, HashSet};
 use std::hash::Hash;
 
 pub use self::one_or_two::OneOrTwo;
@@ -36,12 +36,14 @@ const MIN_TIGHT_SET_CAPACITY: usize = 4;
 // a HashSet that will automatically shrink down in capacity to save space
 #[derive(Clone)]
 pub struct TightSet<T: Hash + Eq> {
-    set: FnvHashSet<T>
+    set: FnvHashSet<T>,
 }
 
-impl <T: Hash + Eq> TightSet<T> {
+impl<T: Hash + Eq> TightSet<T> {
     pub fn new() -> TightSet<T> {
-        TightSet { set : HashSet::with_capacity_and_hasher(MIN_TIGHT_SET_CAPACITY, Default::default()) }
+        TightSet {
+            set: HashSet::with_capacity_and_hasher(MIN_TIGHT_SET_CAPACITY, Default::default()),
+        }
     }
 
     pub fn insert(&mut self, value: T) -> bool {
@@ -49,16 +51,23 @@ impl <T: Hash + Eq> TightSet<T> {
     }
 
     pub fn contains<Q: ?Sized>(&self, value: &Q) -> bool
-        where T: Borrow<Q>, Q: Hash + Eq
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq,
     {
         self.set.contains(value)
     }
 
     pub fn remove<Q: ?Sized>(&mut self, value: &Q) -> bool
-        where T: Borrow<Q>, Q: Hash + Eq
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq,
     {
         let success = self.set.remove(value);
-        if success && self.set.capacity() > MIN_TIGHT_SET_CAPACITY && self.set.capacity() >= self.set.len()*4 {
+        if success
+            && self.set.capacity() > MIN_TIGHT_SET_CAPACITY
+            && self.set.capacity() >= self.set.len() * 4
+        {
             self.set.shrink_to_fit();
         }
         success
@@ -80,7 +89,8 @@ impl <T: Hash + Eq> TightSet<T> {
         if self.set.capacity() <= MIN_TIGHT_SET_CAPACITY {
             self.set.clear();
         } else {
-            self.set = FnvHashSet::with_capacity_and_hasher(MIN_TIGHT_SET_CAPACITY, Default::default());
+            self.set =
+                FnvHashSet::with_capacity_and_hasher(MIN_TIGHT_SET_CAPACITY, Default::default());
         }
     }
 }
@@ -89,36 +99,43 @@ impl <T: Hash + Eq> TightSet<T> {
 mod one_or_two {
     pub enum OneOrTwo<T: Copy + Eq> {
         One(T),
-        Two(T, T)
+        Two(T, T),
     }
 
-    impl <T: Copy + Eq> OneOrTwo<T> {
+    impl<T: Copy + Eq> OneOrTwo<T> {
         pub fn other_id(self, id: T) -> Option<T> {
             match self {
                 OneOrTwo::One(id_1) if id_1 == id => None,
                 OneOrTwo::Two(id_1, id_2) | OneOrTwo::Two(id_2, id_1) if id_1 == id => Some(id_2),
-                _ => panic!()
+                _ => panic!(),
             }
         }
 
         pub fn iter(self) -> Iter<T> {
-            Iter { one_or_two : self, index : 0 }
+            Iter {
+                one_or_two: self,
+                index: 0,
+            }
         }
     }
 
     pub struct Iter<T: Copy + Eq> {
         one_or_two: OneOrTwo<T>,
-        index: u8
+        index: u8,
     }
 
-    impl <T: Copy + Eq> Iterator for Iter<T> {
+    impl<T: Copy + Eq> Iterator for Iter<T> {
         type Item = T;
         fn next(&mut self) -> Option<T> {
             let result = match (&self.one_or_two, self.index) {
-                (&OneOrTwo::One(val), 0) | (&OneOrTwo::Two(val, _), 0) | (&OneOrTwo::Two(_, val), 1) => Some(val),
-                _ => None
+                (&OneOrTwo::One(val), 0)
+                | (&OneOrTwo::Two(val, _), 0)
+                | (&OneOrTwo::Two(_, val), 1) => Some(val),
+                _ => None,
             };
-            if result.is_some() { self.index += 1 }
+            if result.is_some() {
+                self.index += 1
+            }
             result
         }
     }


### PR DESCRIPTION
`cargo fmt --all` brings the code in line with currently accepted formatting guidelines.  I also did some hand editing of comments and other text to make them more readable in a text editor as opposed to online.